### PR TITLE
Feature/issue 23 kafka arena builder pattern

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,9 +95,15 @@ dependencies = [
  "arena",
  "arena-kafka",
  "arena-postgres",
+ "axum 0.7.9",
  "env_logger",
+ "futures",
  "log",
+ "rdkafka",
+ "serde",
+ "serde_json",
  "tokio",
+ "tokio-postgres",
 ]
 
 [[package]]
@@ -106,9 +112,13 @@ version = "0.1.0-alpha.1"
 dependencies = [
  "arena",
  "async-trait",
+ "env_logger",
+ "futures",
  "futures-timer",
  "log",
+ "rdkafka",
  "testcontainers-modules",
+ "tokio",
 ]
 
 [[package]]
@@ -187,18 +197,52 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core 0.4.5",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit 0.7.3",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
- "axum-core",
+ "axum-core 0.5.6",
  "bytes",
  "futures-util",
  "http",
  "http-body",
  "http-body-util",
  "itoa",
- "matchit",
+ "matchit 0.8.4",
  "memchr",
  "mime",
  "percent-encoding",
@@ -208,6 +252,27 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1208,6 +1273,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "libz-sys"
+version = "1.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15d118bbf3771060e7311cc7bb0545b01d08a8b4a7de949198dec1fa0ca1c0f7"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1233,6 +1310,12 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "matchit"
@@ -1379,6 +1462,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1207a7e20ad57b847bbddc6776b968420d38292bbfe2089accff5e19e82454c"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1502,6 +1607,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1610,6 +1721,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1692,6 +1812,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rdkafka"
+version = "0.36.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1beea247b9a7600a81d4cc33f659ce1a77e1988323d7d2809c7ed1c21f4c316d"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "libc",
+ "log",
+ "rdkafka-sys",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "slab",
+ "tokio",
+]
+
+[[package]]
+name = "rdkafka-sys"
+version = "4.9.0+2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5230dca48bc354d718269f3e4353280e188b610f7af7e2fcf54b7a79d5802872"
+dependencies = [
+ "libc",
+ "libz-sys",
+ "num_enum",
+ "pkg-config",
 ]
 
 [[package]]
@@ -1965,6 +2115,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2365,13 +2526,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.23.10+spec-1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+dependencies = [
+ "indexmap 2.12.1",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
 name = "tonic"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb7613188ce9f7df5bfe185db26c5814347d110db17920415cf2fbcad85e7203"
 dependencies = [
  "async-trait",
- "axum",
+ "axum 0.8.8",
  "base64 0.22.1",
  "bytes",
  "h2",
@@ -2441,6 +2632,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -2568,6 +2760,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -2938,6 +3136,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,17 @@ members = ["arena-postgres",
 arena = { path = "arena", version = "0.1.0-alpha.1" }
 arena-kafka = { path = "arena-kafka", version = "0.1.0-alpha.1" }
 arena-postgres = { path = "arena-postgres", version = "0.1.0-alpha.1" }
+axum = "0.7"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio-postgres = "0.7"
+postgres = "0.19"
+rdkafka = { version = "0.36", features = ["tokio"] }
 backon = "1.5.2"
 async-trait = "0.1"
 env_logger = "0.11"
 futures = "0.3"
+futures-timer = "3.0.3"
 log = "0.4"
 testcontainers-modules = "0.14.0"
 tokio = "1"

--- a/arena-kafka/Cargo.toml
+++ b/arena-kafka/Cargo.toml
@@ -11,4 +11,10 @@ arena = { workspace = true }
 async-trait = { workspace = true }
 testcontainers-modules = { workspace = true, features = ["kafka"] }
 log = { workspace = true }
-futures-timer = "3.0.3"
+futures-timer = { workspace = true }
+rdkafka = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+futures = { workspace = true }
+env_logger = { workspace = true }

--- a/arena-kafka/src/builder.rs
+++ b/arena-kafka/src/builder.rs
@@ -1,6 +1,6 @@
 use arena::dependency::RunnableDependency;
-use crate::kafka_container_impl::{ConfluentKafkaContainerImpl, KafkaContainerImpl, KafkaImpl};
-use crate::kafka_dependency::KafkaDependency;
+use crate::kafka_dependency::container_impl::{ConfluentKafkaContainerImpl, KafkaContainerImpl };
+use crate::kafka_dependency::{KafkaDependency, KafkaImpl};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum KafkaFlavor {
@@ -14,7 +14,8 @@ pub struct KafkaDependencyBuilder {
     flavor: KafkaFlavor,
     port: Option<u16>,
     dependencies: Option<Vec<Box<dyn RunnableDependency>>>,
-    container_tag: Option<String>,
+    image_tag: Option<String>,
+    container_name: Option<String>,
 }
 
 impl KafkaDependencyBuilder {
@@ -31,7 +32,8 @@ impl KafkaDependencyBuilder {
             flavor: KafkaFlavor::ApacheNative,
             port: None,
             dependencies: None,
-            container_tag: None,
+            image_tag: None,
+            container_name: None,
         }
     }
 
@@ -61,9 +63,22 @@ impl KafkaDependencyBuilder {
         self
     }
 
-    pub fn with_container_tag(mut self, container_tag: impl Into<String>) -> Self {
-        self.container_tag = Option::from(container_tag.into());
+    pub fn with_image_tag(mut self, image_tag: impl Into<String>) -> Self {
+        self.image_tag = Some(image_tag.into());
         self
+    }
+
+    pub fn with_image(self, image_tag: impl Into<String>) -> Self {
+        self.with_image_tag(image_tag)
+    }
+
+    pub fn with_container_name(mut self, container_name: impl Into<String>) -> Self {
+        self.container_name = Some(container_name.into());
+        self
+    }
+
+    pub fn with_container_tag(self, image_tag: impl Into<String>) -> Self {
+        self.with_image_tag(image_tag)
     }
 
     pub fn build(self) -> KafkaDependency {
@@ -73,7 +88,8 @@ impl KafkaDependencyBuilder {
             flavor,
             port,
             dependencies,
-            container_tag,
+            image_tag,
+            container_name,
         } = self;
 
         let (default_port, default_tag) = match flavor {
@@ -89,9 +105,9 @@ impl KafkaDependencyBuilder {
         });
 
         let port = port.unwrap_or(default_port);
-        let container_tag = container_tag.unwrap_or_else(|| default_tag.to_string());
+        let image_tag = image_tag.unwrap_or_else(|| default_tag.to_string());
 
-        KafkaDependency::new(identifier, kafka_impl, port, dependencies, container_tag)
+        KafkaDependency::new(identifier, kafka_impl, port, dependencies, image_tag, container_name)
     }
 }
 

--- a/arena-kafka/src/kafka_dependency.rs
+++ b/arena-kafka/src/kafka_dependency.rs
@@ -1,25 +1,122 @@
+mod tests;
+
 use arena::dependency::RunnableDependency;
 use async_trait::async_trait;
 use crate::builder::KafkaDependencyBuilder;
 use crate::kafka_container_impl::KafkaImpl;
 use futures_timer::Delay;
-use std::io::{Read, Write};
-use std::net::{SocketAddr, TcpStream, ToSocketAddrs};
-use std::time::{Duration, Instant};
+use rdkafka::config::ClientConfig;
+use rdkafka::admin::{AdminClient, AdminOptions, NewTopic, TopicReplication};
+use rdkafka::consumer::{BaseConsumer, Consumer};
+use rdkafka::message::Message;
+use rdkafka::producer::{FutureProducer, FutureRecord};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-trait ProbeTransport {
-    type Stream: Read + Write;
-    fn connect(&self, bootstrap: &str) -> Result<Self::Stream, String>;
+#[async_trait]
+trait KafkaHealthcheckOps: Send + Sync {
+    async fn create_topic(&self, bootstrap: &str, topic: &str) -> Result<(), String>;
+    async fn delete_topic(&self, bootstrap: &str, topic: &str) -> Result<(), String>;
+    async fn publish(&self, bootstrap: &str, topic: &str, payload: &str) -> Result<(), String>;
+    async fn consume_verify(
+        &self,
+        bootstrap: &str,
+        topic: &str,
+        expected_payload: &str,
+    ) -> Result<bool, String>;
 }
 
-struct TcpProbeTransport;
+struct RdkafkaHealthcheckOps;
 
-impl ProbeTransport for TcpProbeTransport {
-    type Stream = TcpStream;
+#[async_trait]
+impl KafkaHealthcheckOps for RdkafkaHealthcheckOps {
+    async fn create_topic(&self, bootstrap: &str, topic: &str) -> Result<(), String> {
+        let admin: AdminClient<_> = ClientConfig::new()
+            .set("bootstrap.servers", bootstrap)
+            .create()
+            .map_err(|e| format!("create kafka admin client failed: {e}"))?;
 
-    fn connect(&self, bootstrap: &str) -> Result<Self::Stream, String> {
-        let addr = KafkaDependency::resolve_bootstrap_addr(bootstrap)?;
-        KafkaDependency::connect_with_timeout(addr)
+        let new_topic = NewTopic::new(topic, 1, TopicReplication::Fixed(1));
+        let opts = AdminOptions::new().operation_timeout(Some(Duration::from_secs(2)));
+
+        match admin.create_topics([&new_topic], &opts).await {
+            Ok(results) => {
+                for r in results {
+                    if let Err((_t, e)) = r {
+                        if e.to_string().to_lowercase().contains("already exists") {
+                            return Ok(());
+                        }
+                        return Err(format!("kafka topic create failed: {e}"));
+                    }
+                }
+                Ok(())
+            }
+            Err(err) => Err(format!("kafka topic create request failed: {err}")),
+        }
+    }
+
+    async fn delete_topic(&self, bootstrap: &str, topic: &str) -> Result<(), String> {
+        let admin: AdminClient<_> = ClientConfig::new()
+            .set("bootstrap.servers", bootstrap)
+            .create()
+            .map_err(|e| format!("create kafka admin client failed: {e}"))?;
+
+        let opts = AdminOptions::new().operation_timeout(Some(Duration::from_secs(2)));
+        admin
+            .delete_topics(&[topic], &opts)
+            .await
+            .map(|_res| ())
+            .map_err(|e| format!("kafka topic delete failed: {e}"))
+    }
+
+    async fn publish(&self, bootstrap: &str, topic: &str, payload: &str) -> Result<(), String> {
+        let producer: FutureProducer = ClientConfig::new()
+            .set("bootstrap.servers", bootstrap)
+            .set("message.timeout.ms", "2000")
+            .create()
+            .map_err(|e| format!("create kafka producer failed: {e}"))?;
+
+        let record = FutureRecord::to(topic).key("healthcheck").payload(payload);
+        producer
+            .send(record, Duration::from_secs(2))
+            .await
+            .map(|_| ())
+            .map_err(|(e, _msg)| format!("kafka publish failed: {e}"))
+    }
+
+    async fn consume_verify(
+        &self,
+        bootstrap: &str,
+        topic: &str,
+        expected_payload: &str,
+    ) -> Result<bool, String> {
+        let consumer: BaseConsumer = ClientConfig::new()
+            .set("bootstrap.servers", bootstrap)
+            .set("group.id", format!("arena-healthcheck-{topic}"))
+            .set("enable.auto.commit", "false")
+            .set("auto.offset.reset", "earliest")
+            .set("session.timeout.ms", "6000")
+            .create()
+            .map_err(|e| format!("create kafka consumer failed: {e}"))?;
+
+        consumer
+            .subscribe(&[topic])
+            .map_err(|e| format!("kafka subscribe failed: {e}"))?;
+
+        let consume_deadline = Instant::now() + Duration::from_secs(5);
+        while Instant::now() < consume_deadline {
+            match consumer.poll(Duration::from_millis(250)) {
+                None => {}
+                Some(Err(err)) => return Err(format!("kafka consume failed: {err}")),
+                Some(Ok(msg)) => {
+                    if let Some(bytes) = msg.payload() {
+                        if bytes == expected_payload.as_bytes() {
+                            return Ok(true);
+                        }
+                    }
+                }
+            }
+        }
+        Ok(false)
     }
 }
 
@@ -29,7 +126,9 @@ pub struct KafkaDependency {
     port: u16,
     dependencies: Option<Vec<Box<dyn RunnableDependency>>>,
     running: bool,
-    container_tag: String,
+    image_tag: String,
+    container_name: Option<String>,
+    healthcheck_ops: Box<dyn KafkaHealthcheckOps>,
 }
 
 impl KafkaDependency {
@@ -38,15 +137,18 @@ impl KafkaDependency {
         kafka_impl: Box<dyn KafkaImpl>,
         port: u16,
         dependencies: Option<Vec<Box<dyn RunnableDependency>>>,
-        container_tag: String,
+        image_tag: String,
+        container_name: Option<String>,
     ) -> Self {
         KafkaDependency {
             identifier,
             kafka_impl,
             port,
             dependencies,
-            container_tag,
+            image_tag,
+            container_name,
             running: false,
+            healthcheck_ops: Box::new(RdkafkaHealthcheckOps),
         }
     }
 
@@ -58,113 +160,121 @@ impl KafkaDependency {
         KafkaDependencyBuilder::new(identifier)
     }
 
-    fn readiness_bootstrap_on_host(&self) -> Result<&str, String> {
+    fn sanitize_identifier(input: &str) -> String {
+        let mut safe = String::with_capacity(input.len());
+        for c in input.chars() {
+            let c = c.to_ascii_lowercase();
+            if c.is_ascii_alphanumeric() {
+                safe.push(c);
+            } else {
+                safe.push('-');
+            }
+        }
+        safe
+    }
+
+    fn default_container_name(&self) -> String {
+        let safe = Self::sanitize_identifier(&self.identifier);
+
+        let ts = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis();
+
+        format!("arena-kafka-{safe}-{ts}")
+    }
+
+    fn bootstrap_on_host(&self) -> Result<&str, String> {
         self.bootstrap_servers()
             .ok_or_else(|| "kafka bootstrap servers not available yet".to_string())
     }
 
-    fn resolve_bootstrap_addr(bootstrap: &str) -> Result<SocketAddr, String> {
-        let addr: SocketAddr = bootstrap
-            .to_socket_addrs()
-            .map_err(|e| format!("resolve bootstrap {bootstrap:?} failed: {e}"))?
-            .next()
-            .ok_or_else(|| format!("resolve bootstrap {bootstrap:?} produced no addresses"))?;
-        Ok(addr)
+    fn healthcheck_topic_name(identifier: &str) -> String {
+        let safe = Self::sanitize_identifier(identifier);
+
+        let ts = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis();
+
+        format!("arena_healthcheck_{safe}_{ts}")
     }
 
-    fn connect_with_timeout(addr: SocketAddr) -> Result<TcpStream, String> {
-        let stream = TcpStream::connect_timeout(&addr, Duration::from_millis(250))
-            .map_err(|e| format!("tcp connect to {addr} failed: {e}"))?;
-        stream
-            .set_read_timeout(Some(Duration::from_millis(250)))
-            .ok();
-        stream
-            .set_write_timeout(Some(Duration::from_millis(250)))
-            .ok();
-        Ok(stream)
-    }
-
-    fn build_api_versions_request_v0(correlation_id: i32) -> Result<Vec<u8>, String> {
-        const API_KEY_API_VERSIONS: i16 = 18;
-        const API_VERSION: i16 = 0;
-
-        let mut body: Vec<u8> = Vec::with_capacity(16);
-        body.extend_from_slice(&API_KEY_API_VERSIONS.to_be_bytes());
-        body.extend_from_slice(&API_VERSION.to_be_bytes());
-        body.extend_from_slice(&correlation_id.to_be_bytes());
-        body.extend_from_slice(&(0i16).to_be_bytes()); // client_id length = 0
-
-        let len: i32 = body
-            .len()
-            .try_into()
-            .map_err(|_| "request too large".to_string())?;
-
-        let mut frame: Vec<u8> = Vec::with_capacity(4 + body.len());
-        frame.extend_from_slice(&len.to_be_bytes());
-        frame.extend_from_slice(&body);
-        Ok(frame)
-    }
-
-    fn write_kafka_frame<S: Write>(stream: &mut S, frame: &[u8]) -> Result<(), String> {
-        stream
-            .write_all(frame)
-            .map_err(|e| format!("kafka probe write failed: {e}"))?;
-        stream.flush().ok();
-        Ok(())
-    }
-
-    fn read_kafka_frame<S: Read>(stream: &mut S) -> Result<Vec<u8>, String> {
-        let mut size_buf = [0u8; 4];
-        stream
-            .read_exact(&mut size_buf)
-            .map_err(|e| format!("kafka probe read size failed: {e}"))?;
-        let size = i32::from_be_bytes(size_buf);
-        if size <= 0 || size > 1024 * 1024 {
-            return Err(format!("kafka probe invalid response size: {size}"));
-        }
-
-        let mut resp = vec![0u8; size as usize];
-        stream
-            .read_exact(&mut resp)
-            .map_err(|e| format!("kafka probe read payload failed: {e}"))?;
-        Ok(resp)
-    }
-
-    fn parse_response_correlation_id(resp: &[u8]) -> Result<i32, String> {
-        if resp.len() < 4 {
-            return Err("kafka probe response too short".to_string());
-        }
-        Ok(i32::from_be_bytes([resp[0], resp[1], resp[2], resp[3]]))
-    }
-
-    fn kafka_probe_api_versions_with_transport<T: ProbeTransport>(
-        transport: &T,
+    async fn create_healthcheck_topic_with_retry(
+        ops: &dyn KafkaHealthcheckOps,
         bootstrap: &str,
+        topic: &str,
+        timeout: Duration,
     ) -> Result<(), String> {
-        const CORRELATION_ID: i32 = 1;
-        let mut stream = transport.connect(bootstrap)?;
-        let frame = Self::build_api_versions_request_v0(CORRELATION_ID)?;
-        Self::write_kafka_frame(&mut stream, &frame)?;
-        let resp = Self::read_kafka_frame(&mut stream)?;
-        let corr = Self::parse_response_correlation_id(&resp)?;
-        if corr != CORRELATION_ID {
-            return Err(format!(
-                "kafka probe correlation mismatch: expected {CORRELATION_ID} got {corr}"
-            ));
-        }
-        Ok(())
-    }
-
-    fn kafka_probe_api_versions(bootstrap: &str) -> Result<(), String> {
-        Self::kafka_probe_api_versions_with_transport(&TcpProbeTransport, bootstrap)
-    }
-
-    async fn wait_for_protocol_ready(&self) {
-        let timeout = Duration::from_secs(15);
+        #[cfg(test)]
+        let poll_every = Duration::from_millis(1);
+        #[cfg(not(test))]
         let poll_every = Duration::from_millis(250);
         let start = Instant::now();
 
         loop {
+            if start.elapsed() >= timeout {
+                return Err(format!("kafka healthcheck topic create timed out: {topic}"));
+            }
+
+            match ops.create_topic(bootstrap, topic).await {
+                Ok(()) => return Ok(()),
+                Err(err) => log::debug!("[Kafka] healthcheck topic create failed: {err}"),
+            }
+
+            Delay::new(poll_every).await;
+        }
+    }
+
+    async fn healthcheck_roundtrip(&self, bootstrap: &str) -> Result<(), String> {
+        let topic = Self::healthcheck_topic_name(&self.identifier);
+
+        Self::create_healthcheck_topic_with_retry(
+            self.healthcheck_ops.as_ref(),
+            bootstrap,
+            &topic,
+            Duration::from_secs(10),
+        )
+        .await?;
+
+        let payload = format!("arena-healthcheck-{topic}");
+
+        if let Err(err) = self
+            .healthcheck_ops
+            .publish(bootstrap, &topic, &payload)
+            .await
+        {
+            let _ = self.healthcheck_ops.delete_topic(bootstrap, &topic).await;
+            return Err(err);
+        }
+
+        let saw = match self
+            .healthcheck_ops
+            .consume_verify(bootstrap, &topic, &payload)
+            .await
+        {
+            Ok(v) => v,
+            Err(err) => {
+                let _ = self.healthcheck_ops.delete_topic(bootstrap, &topic).await;
+                return Err(err);
+            }
+        };
+
+        let _ = self.healthcheck_ops.delete_topic(bootstrap, &topic).await;
+
+        if !saw {
+            return Err("kafka healthcheck did not observe published message".to_string());
+        }
+
+        Ok(())
+    }
+
+    async fn wait_until_ready(&self) {
+        let timeout = Duration::from_secs(15);
+        let poll_every = Duration::from_millis(250);
+        let start = Instant::now();
+
+        let bootstrap = loop {
             if start.elapsed() >= timeout {
                 panic!(
                     "[Kafka-{}] kafka did not become ready within {:?}",
@@ -172,36 +282,36 @@ impl KafkaDependency {
                 );
             }
 
-            let bootstrap = match self.readiness_bootstrap_on_host() {
-                Ok(v) => v.to_string(),
+            match self.bootstrap_on_host() {
+                Ok(v) => break v.to_string(),
                 Err(err) => {
                     log::debug!("[Kafka-{}] readiness bootstrap missing: {}", self.identifier, err);
                     Delay::new(poll_every).await;
-                    continue;
-                }
-            };
-
-            match Self::kafka_probe_api_versions(&bootstrap) {
-                Ok(()) => return,
-                Err(err) => {
-                    log::debug!(
-                        "[Kafka-{}] readiness check failed (will retry): {}",
-                        self.identifier,
-                        err
-                    );
-                    Delay::new(poll_every).await;
                 }
             }
-        }
-    }
+        };
 
-    async fn is_ready(&self) {
-        self.wait_for_protocol_ready().await;
+        match self.healthcheck_roundtrip(&bootstrap).await {
+            Ok(()) => {}
+            Err(err) => panic!("[Kafka-{}] readiness check failed: {}", self.identifier, err),
+        }
     }
 }
 
 #[async_trait]
 impl RunnableDependency for KafkaDependency {
+    fn identifier(&self) -> &str {
+        &self.identifier
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
     async fn start(&mut self) {
         if self.running {
             return;
@@ -214,10 +324,16 @@ impl RunnableDependency for KafkaDependency {
             dep.start().await;
         }
 
-        let container_tag = self.container_tag.clone();
+        let image_tag = self.image_tag.clone();
+        let container_name = self
+            .container_name
+            .clone()
+            .unwrap_or_else(|| self.default_container_name());
 
         let sw_container = Instant::now();
-        self.kafka_impl.start(self.port, &container_tag).await;
+        self.kafka_impl
+            .start(self.port, &image_tag, &container_name)
+            .await;
         log::debug!(
             "[Kafka-{}] container start in {:?}.",
             self.identifier,
@@ -225,7 +341,7 @@ impl RunnableDependency for KafkaDependency {
         );
 
         let sw_ready = Instant::now();
-        self.is_ready().await;
+        self.wait_until_ready().await;
         log::debug!(
             "[Kafka-{}] readiness in {:?}.",
             self.identifier,
@@ -266,84 +382,5 @@ impl RunnableDependency for KafkaDependency {
 
     fn add_child(&mut self, dep: Box<dyn RunnableDependency>) {
         self.dependencies.get_or_insert_with(Vec::new).push(dep);
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::KafkaDependency;
-    use super::ProbeTransport;
-    use std::io::{Cursor, Read, Write};
-
-    struct FakeStream {
-        read: Cursor<Vec<u8>>,
-        written: Vec<u8>,
-    }
-
-    impl Read for FakeStream {
-        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-            self.read.read(buf)
-        }
-    }
-
-    impl Write for FakeStream {
-        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-            self.written.extend_from_slice(buf);
-            Ok(buf.len())
-        }
-
-        fn flush(&mut self) -> std::io::Result<()> {
-            Ok(())
-        }
-    }
-
-    struct FakeTransport {
-        stream: FakeStream,
-    }
-
-    impl ProbeTransport for FakeTransport {
-        type Stream = FakeStream;
-
-        fn connect(&self, _bootstrap: &str) -> Result<Self::Stream, String> {
-            Ok(FakeStream {
-                read: Cursor::new(self.stream.read.get_ref().clone()),
-                written: Vec::new(),
-            })
-        }
-    }
-
-    fn response_frame_with_corr(corr: i32) -> Vec<u8> {
-        let payload = corr.to_be_bytes().to_vec();
-        let mut out = Vec::new();
-        out.extend_from_slice(&(payload.len() as i32).to_be_bytes());
-        out.extend_from_slice(&payload);
-        out
-    }
-
-    #[test]
-    fn probe_api_versions_succeeds_with_matching_correlation_id() {
-        let transport = FakeTransport {
-            stream: FakeStream {
-                read: Cursor::new(response_frame_with_corr(1)),
-                written: Vec::new(),
-            },
-        };
-
-        KafkaDependency::kafka_probe_api_versions_with_transport(&transport, "ignored")
-            .expect("probe should succeed");
-    }
-
-    #[test]
-    fn probe_api_versions_fails_with_mismatched_correlation_id() {
-        let transport = FakeTransport {
-            stream: FakeStream {
-                read: Cursor::new(response_frame_with_corr(2)),
-                written: Vec::new(),
-            },
-        };
-
-        let err = KafkaDependency::kafka_probe_api_versions_with_transport(&transport, "ignored")
-            .expect_err("probe should fail");
-        assert!(err.contains("correlation mismatch"), "err was: {err}");
     }
 }

--- a/arena-kafka/src/kafka_dependency.rs
+++ b/arena-kafka/src/kafka_dependency.rs
@@ -1,123 +1,33 @@
-mod tests;
+#[cfg(test)]
+mod unit_tests;
+mod healthcheck;
+pub(crate) mod container_impl;
 
 use arena::dependency::RunnableDependency;
 use async_trait::async_trait;
 use crate::builder::KafkaDependencyBuilder;
-use crate::kafka_container_impl::KafkaImpl;
 use futures_timer::Delay;
-use rdkafka::config::ClientConfig;
-use rdkafka::admin::{AdminClient, AdminOptions, NewTopic, TopicReplication};
-use rdkafka::consumer::{BaseConsumer, Consumer};
-use rdkafka::message::Message;
-use rdkafka::producer::{FutureProducer, FutureRecord};
+use crate::kafka_dependency::healthcheck::{KafkaHealthcheckOps, RdkafkaHealthcheckOps};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 #[async_trait]
-trait KafkaHealthcheckOps: Send + Sync {
-    async fn create_topic(&self, bootstrap: &str, topic: &str) -> Result<(), String>;
-    async fn delete_topic(&self, bootstrap: &str, topic: &str) -> Result<(), String>;
-    async fn publish(&self, bootstrap: &str, topic: &str, payload: &str) -> Result<(), String>;
-    async fn consume_verify(
-        &self,
-        bootstrap: &str,
-        topic: &str,
-        expected_payload: &str,
-    ) -> Result<bool, String>;
+pub trait KafkaImpl: Send + Sync {
+    async fn start(&mut self, port: u16, image_tag: &str, container_name: &str);
+    async fn stop(&mut self);
+    fn bootstrap_servers(&self) -> Option<&str>;
 }
 
-struct RdkafkaHealthcheckOps;
-
-#[async_trait]
-impl KafkaHealthcheckOps for RdkafkaHealthcheckOps {
-    async fn create_topic(&self, bootstrap: &str, topic: &str) -> Result<(), String> {
-        let admin: AdminClient<_> = ClientConfig::new()
-            .set("bootstrap.servers", bootstrap)
-            .create()
-            .map_err(|e| format!("create kafka admin client failed: {e}"))?;
-
-        let new_topic = NewTopic::new(topic, 1, TopicReplication::Fixed(1));
-        let opts = AdminOptions::new().operation_timeout(Some(Duration::from_secs(2)));
-
-        match admin.create_topics([&new_topic], &opts).await {
-            Ok(results) => {
-                for r in results {
-                    if let Err((_t, e)) = r {
-                        if e.to_string().to_lowercase().contains("already exists") {
-                            return Ok(());
-                        }
-                        return Err(format!("kafka topic create failed: {e}"));
-                    }
-                }
-                Ok(())
-            }
-            Err(err) => Err(format!("kafka topic create request failed: {err}")),
+fn sanitize_identifier(input: &str) -> String {
+    let mut safe = String::with_capacity(input.len());
+    for c in input.chars() {
+        let c = c.to_ascii_lowercase();
+        if c.is_ascii_alphanumeric() {
+            safe.push(c);
+        } else {
+            safe.push('-');
         }
     }
-
-    async fn delete_topic(&self, bootstrap: &str, topic: &str) -> Result<(), String> {
-        let admin: AdminClient<_> = ClientConfig::new()
-            .set("bootstrap.servers", bootstrap)
-            .create()
-            .map_err(|e| format!("create kafka admin client failed: {e}"))?;
-
-        let opts = AdminOptions::new().operation_timeout(Some(Duration::from_secs(2)));
-        admin
-            .delete_topics(&[topic], &opts)
-            .await
-            .map(|_res| ())
-            .map_err(|e| format!("kafka topic delete failed: {e}"))
-    }
-
-    async fn publish(&self, bootstrap: &str, topic: &str, payload: &str) -> Result<(), String> {
-        let producer: FutureProducer = ClientConfig::new()
-            .set("bootstrap.servers", bootstrap)
-            .set("message.timeout.ms", "2000")
-            .create()
-            .map_err(|e| format!("create kafka producer failed: {e}"))?;
-
-        let record = FutureRecord::to(topic).key("healthcheck").payload(payload);
-        producer
-            .send(record, Duration::from_secs(2))
-            .await
-            .map(|_| ())
-            .map_err(|(e, _msg)| format!("kafka publish failed: {e}"))
-    }
-
-    async fn consume_verify(
-        &self,
-        bootstrap: &str,
-        topic: &str,
-        expected_payload: &str,
-    ) -> Result<bool, String> {
-        let consumer: BaseConsumer = ClientConfig::new()
-            .set("bootstrap.servers", bootstrap)
-            .set("group.id", format!("arena-healthcheck-{topic}"))
-            .set("enable.auto.commit", "false")
-            .set("auto.offset.reset", "earliest")
-            .set("session.timeout.ms", "6000")
-            .create()
-            .map_err(|e| format!("create kafka consumer failed: {e}"))?;
-
-        consumer
-            .subscribe(&[topic])
-            .map_err(|e| format!("kafka subscribe failed: {e}"))?;
-
-        let consume_deadline = Instant::now() + Duration::from_secs(5);
-        while Instant::now() < consume_deadline {
-            match consumer.poll(Duration::from_millis(250)) {
-                None => {}
-                Some(Err(err)) => return Err(format!("kafka consume failed: {err}")),
-                Some(Ok(msg)) => {
-                    if let Some(bytes) = msg.payload() {
-                        if bytes == expected_payload.as_bytes() {
-                            return Ok(true);
-                        }
-                    }
-                }
-            }
-        }
-        Ok(false)
-    }
+    safe
 }
 
 pub struct KafkaDependency {
@@ -160,21 +70,8 @@ impl KafkaDependency {
         KafkaDependencyBuilder::new(identifier)
     }
 
-    fn sanitize_identifier(input: &str) -> String {
-        let mut safe = String::with_capacity(input.len());
-        for c in input.chars() {
-            let c = c.to_ascii_lowercase();
-            if c.is_ascii_alphanumeric() {
-                safe.push(c);
-            } else {
-                safe.push('-');
-            }
-        }
-        safe
-    }
-
     fn default_container_name(&self) -> String {
-        let safe = Self::sanitize_identifier(&self.identifier);
+        let safe = sanitize_identifier(&self.identifier);
 
         let ts = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -187,86 +84,6 @@ impl KafkaDependency {
     fn bootstrap_on_host(&self) -> Result<&str, String> {
         self.bootstrap_servers()
             .ok_or_else(|| "kafka bootstrap servers not available yet".to_string())
-    }
-
-    fn healthcheck_topic_name(identifier: &str) -> String {
-        let safe = Self::sanitize_identifier(identifier);
-
-        let ts = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis();
-
-        format!("arena_healthcheck_{safe}_{ts}")
-    }
-
-    async fn create_healthcheck_topic_with_retry(
-        ops: &dyn KafkaHealthcheckOps,
-        bootstrap: &str,
-        topic: &str,
-        timeout: Duration,
-    ) -> Result<(), String> {
-        #[cfg(test)]
-        let poll_every = Duration::from_millis(1);
-        #[cfg(not(test))]
-        let poll_every = Duration::from_millis(250);
-        let start = Instant::now();
-
-        loop {
-            if start.elapsed() >= timeout {
-                return Err(format!("kafka healthcheck topic create timed out: {topic}"));
-            }
-
-            match ops.create_topic(bootstrap, topic).await {
-                Ok(()) => return Ok(()),
-                Err(err) => log::debug!("[Kafka] healthcheck topic create failed: {err}"),
-            }
-
-            Delay::new(poll_every).await;
-        }
-    }
-
-    async fn healthcheck_roundtrip(&self, bootstrap: &str) -> Result<(), String> {
-        let topic = Self::healthcheck_topic_name(&self.identifier);
-
-        Self::create_healthcheck_topic_with_retry(
-            self.healthcheck_ops.as_ref(),
-            bootstrap,
-            &topic,
-            Duration::from_secs(10),
-        )
-        .await?;
-
-        let payload = format!("arena-healthcheck-{topic}");
-
-        if let Err(err) = self
-            .healthcheck_ops
-            .publish(bootstrap, &topic, &payload)
-            .await
-        {
-            let _ = self.healthcheck_ops.delete_topic(bootstrap, &topic).await;
-            return Err(err);
-        }
-
-        let saw = match self
-            .healthcheck_ops
-            .consume_verify(bootstrap, &topic, &payload)
-            .await
-        {
-            Ok(v) => v,
-            Err(err) => {
-                let _ = self.healthcheck_ops.delete_topic(bootstrap, &topic).await;
-                return Err(err);
-            }
-        };
-
-        let _ = self.healthcheck_ops.delete_topic(bootstrap, &topic).await;
-
-        if !saw {
-            return Err("kafka healthcheck did not observe published message".to_string());
-        }
-
-        Ok(())
     }
 
     async fn wait_until_ready(&self) {
@@ -291,10 +108,25 @@ impl KafkaDependency {
             }
         };
 
-        match self.healthcheck_roundtrip(&bootstrap).await {
+        let remaining = timeout.saturating_sub(start.elapsed());
+        if remaining.is_zero() {
+            panic!(
+                "[Kafka-{}] kafka did not become ready within {:?}",
+                self.identifier, timeout
+            );
+        }
+
+        match healthcheck::run_with_retry(
+            self.healthcheck_ops.as_ref(),
+            &self.identifier,
+            &bootstrap,
+            remaining,
+        )
+        .await
+        {
             Ok(()) => {}
             Err(err) => panic!("[Kafka-{}] readiness check failed: {}", self.identifier, err),
-        }
+        };
     }
 }
 

--- a/arena-kafka/src/kafka_dependency/container_impl.rs
+++ b/arena-kafka/src/kafka_dependency/container_impl.rs
@@ -3,17 +3,16 @@ use std::time::Duration;
 use testcontainers_modules::{kafka, testcontainers, testcontainers::runners::AsyncRunner};
 use testcontainers_modules::testcontainers::core::{ContainerPort, Healthcheck};
 use testcontainers_modules::testcontainers::ImageExt;
+use crate::kafka_dependency::KafkaImpl;
 
-#[async_trait]
-pub trait KafkaImpl: Send + Sync {
-    async fn start(&mut self, port: u16, container_tag: &str);
-    async fn stop(&mut self);
-
-    fn bootstrap_servers(&self) -> Option<&str>;
+fn tcp_healthcheck(port: u16) -> Healthcheck {
+    Healthcheck::cmd_shell(format!("bash -lc 'echo > /dev/tcp/127.0.0.1/{port}'"))
+        .with_interval(Duration::from_millis(250))
+        .with_timeout(Duration::from_secs(1))
+        .with_retries(40u32)
 }
 
 pub(crate) struct KafkaContainerImpl {
-    // `testcontainers-modules` Apache Kafka defaults to `apache/kafka-native`.
     container: Option<testcontainers::core::ContainerAsync<kafka::apache::Kafka>>,
     bootstrap: Option<String>,
 }
@@ -29,30 +28,20 @@ impl KafkaContainerImpl {
 
 #[async_trait]
 impl KafkaImpl for KafkaContainerImpl {
-    async fn start(&mut self, port: u16, container_tag: &str) {
+    async fn start(&mut self, port: u16, image_tag: &str, container_name: &str) {
         if self.container.is_some() {
             return;
         }
 
         const DEFAULT_CONTAINER_PORT: ContainerPort = kafka::apache::KAFKA_PORT;
 
-        // Internal "good enough" healthcheck for now. We'll make it configurable later.
-        //
-        // This relies on bash's /dev/tcp support. If this ever fails on a future image,
-        // we'll swap to a more explicit Kafka readiness command.
-        let healthcheck = Healthcheck::cmd_shell(format!(
-            "bash -lc 'echo > /dev/tcp/127.0.0.1/{port}'",
-            port = DEFAULT_CONTAINER_PORT.as_u16()
-        ))
-        .with_interval(Duration::from_millis(250))
-        .with_timeout(Duration::from_secs(1))
-        // 10s / 250ms = 40 attempts (ish)
-        .with_retries(40u32);
+        let healthcheck = tcp_healthcheck(DEFAULT_CONTAINER_PORT.as_u16());
 
         let container = kafka::apache::Kafka::default()
-            .with_tag(container_tag)
+            .with_tag(image_tag)
             .with_mapped_port(port, DEFAULT_CONTAINER_PORT)
             .with_health_check(healthcheck)
+            .with_container_name(container_name)
             .start()
             .await
             .expect("start kafka container");
@@ -102,26 +91,20 @@ impl ConfluentKafkaContainerImpl {
 
 #[async_trait]
 impl KafkaImpl for ConfluentKafkaContainerImpl {
-    async fn start(&mut self, port: u16, container_tag: &str) {
+    async fn start(&mut self, port: u16, image_tag: &str, container_name: &str) {
         if self.container.is_some() {
             return;
         }
 
         const DEFAULT_CONTAINER_PORT: ContainerPort = kafka::confluent::KAFKA_PORT;
 
-        // Internal "good enough" healthcheck for now. We'll make it configurable later.
-        let healthcheck = Healthcheck::cmd_shell(format!(
-            "bash -lc 'echo > /dev/tcp/127.0.0.1/{port}'",
-            port = DEFAULT_CONTAINER_PORT.as_u16()
-        ))
-        .with_interval(Duration::from_millis(250))
-        .with_timeout(Duration::from_secs(1))
-        .with_retries(40u32);
+        let healthcheck = tcp_healthcheck(DEFAULT_CONTAINER_PORT.as_u16());
 
         let container = kafka::confluent::Kafka::default()
-            .with_tag(container_tag)
+            .with_tag(image_tag)
             .with_mapped_port(port, DEFAULT_CONTAINER_PORT)
             .with_health_check(healthcheck)
+            .with_container_name(container_name)
             .start()
             .await
             .expect("start kafka container");

--- a/arena-kafka/src/kafka_dependency/healthcheck.rs
+++ b/arena-kafka/src/kafka_dependency/healthcheck.rs
@@ -1,0 +1,177 @@
+use async_trait::async_trait;
+use futures_timer::Delay;
+use rdkafka::admin::{AdminClient, AdminOptions, NewTopic, TopicReplication};
+use rdkafka::config::ClientConfig;
+use rdkafka::consumer::{BaseConsumer, Consumer};
+use rdkafka::message::Message;
+use rdkafka::producer::{FutureProducer, FutureRecord};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+#[async_trait]
+pub(super) trait KafkaHealthcheckOps: Send + Sync {
+    async fn create_topic(&self, bootstrap: &str, topic: &str) -> Result<(), String>;
+    async fn delete_topic(&self, bootstrap: &str, topic: &str) -> Result<(), String>;
+    async fn publish(&self, bootstrap: &str, topic: &str, payload: &str) -> Result<(), String>;
+    async fn consume_verify(
+        &self,
+        bootstrap: &str,
+        topic: &str,
+        expected_payload: &str,
+    ) -> Result<bool, String>;
+}
+
+pub(super) struct RdkafkaHealthcheckOps;
+
+fn healthcheck_topic_name(identifier: &str) -> String {
+    let safe = super::sanitize_identifier(identifier);
+    let ts = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis();
+    format!("arena_healthcheck_{safe}_{ts}")
+}
+
+#[async_trait]
+impl KafkaHealthcheckOps for RdkafkaHealthcheckOps {
+    async fn create_topic(&self, bootstrap: &str, topic: &str) -> Result<(), String> {
+        let admin: AdminClient<_> = ClientConfig::new()
+            .set("bootstrap.servers", bootstrap)
+            .create()
+            .map_err(|e| format!("create kafka admin client failed: {e}"))?;
+
+        let new_topic = NewTopic::new(topic, 1, TopicReplication::Fixed(1));
+        let opts = AdminOptions::new().operation_timeout(Some(Duration::from_secs(2)));
+
+        match admin.create_topics([&new_topic], &opts).await {
+            Ok(results) => {
+                for r in results {
+                    if let Err((_t, e)) = r {
+                        if e.to_string().to_lowercase().contains("already exists") {
+                            return Ok(());
+                        }
+                        return Err(format!("kafka topic create failed: {e}"));
+                    }
+                }
+                Ok(())
+            }
+            Err(err) => Err(format!("kafka topic create request failed: {err}")),
+        }
+    }
+
+    async fn delete_topic(&self, bootstrap: &str, topic: &str) -> Result<(), String> {
+        let admin: AdminClient<_> = ClientConfig::new()
+            .set("bootstrap.servers", bootstrap)
+            .create()
+            .map_err(|e| format!("create kafka admin client failed: {e}"))?;
+
+        let opts = AdminOptions::new().operation_timeout(Some(Duration::from_secs(2)));
+        admin
+            .delete_topics(&[topic], &opts)
+            .await
+            .map(|_res| ())
+            .map_err(|e| format!("kafka topic delete failed: {e}"))
+    }
+
+    async fn publish(&self, bootstrap: &str, topic: &str, payload: &str) -> Result<(), String> {
+        let producer: FutureProducer = ClientConfig::new()
+            .set("bootstrap.servers", bootstrap)
+            .set("message.timeout.ms", "2000")
+            .create()
+            .map_err(|e| format!("create kafka producer failed: {e}"))?;
+
+        let record = FutureRecord::to(topic).key("healthcheck").payload(payload);
+        producer
+            .send(record, Duration::from_secs(2))
+            .await
+            .map(|_| ())
+            .map_err(|(e, _msg)| format!("kafka publish failed: {e}"))
+    }
+
+    async fn consume_verify(
+        &self,
+        bootstrap: &str,
+        topic: &str,
+        expected_payload: &str,
+    ) -> Result<bool, String> {
+        let consumer: BaseConsumer = ClientConfig::new()
+            .set("bootstrap.servers", bootstrap)
+            .set("group.id", format!("arena-healthcheck-{topic}"))
+            .set("enable.auto.commit", "false")
+            .set("auto.offset.reset", "earliest")
+            .set("session.timeout.ms", "6000")
+            .create()
+            .map_err(|e| format!("create kafka consumer failed: {e}"))?;
+
+        consumer
+            .subscribe(&[topic])
+            .map_err(|e| format!("kafka subscribe failed: {e}"))?;
+
+        let consume_deadline = Instant::now() + Duration::from_secs(5);
+        while Instant::now() < consume_deadline {
+            match consumer.poll(Duration::from_millis(250)) {
+                None => {}
+                Some(Err(err)) => return Err(format!("kafka consume failed: {err}")),
+                Some(Ok(msg)) => {
+                    if let Some(bytes) = msg.payload() {
+                        if bytes == expected_payload.as_bytes() {
+                            return Ok(true);
+                        }
+                    }
+                }
+            }
+        }
+        Ok(false)
+    }
+}
+
+async fn roundtrip_once(
+    ops: &dyn KafkaHealthcheckOps,
+    bootstrap: &str,
+    topic: &str,
+) -> Result<(), String> {
+    ops.create_topic(bootstrap, topic).await?;
+
+    let payload = format!("arena-healthcheck-{topic}");
+    ops.publish(bootstrap, topic, &payload).await?;
+
+    let saw = ops.consume_verify(bootstrap, topic, &payload).await?;
+    if !saw {
+        return Err("kafka healthcheck did not observe published message".to_string());
+    }
+
+    Ok(())
+}
+
+pub(super) async fn run_with_retry(
+    ops: &dyn KafkaHealthcheckOps,
+    identifier: &str,
+    bootstrap: &str,
+    timeout: Duration,
+) -> Result<(), String> {
+    let topic = healthcheck_topic_name(identifier);
+
+    #[cfg(test)]
+    let poll_every = Duration::from_millis(1);
+    #[cfg(not(test))]
+    let poll_every = Duration::from_millis(250);
+
+    let start = Instant::now();
+    loop {
+        if start.elapsed() >= timeout {
+            return Err(format!("kafka healthcheck timed out (topic={topic})"));
+        }
+
+        let res = roundtrip_once(ops, bootstrap, &topic).await;
+
+        let _ = ops.delete_topic(bootstrap, &topic).await;
+
+        match res {
+            Ok(()) => return Ok(()),
+            Err(err) => {
+                log::debug!("[Kafka] healthcheck failed (will retry): {err}");
+                Delay::new(poll_every).await;
+            }
+        }
+    }
+}
+

--- a/arena-kafka/src/kafka_dependency/unit_tests.rs
+++ b/arena-kafka/src/kafka_dependency/unit_tests.rs
@@ -1,0 +1,158 @@
+use super::*;
+use async_trait::async_trait;
+use std::sync::{Arc, Mutex};
+use super::healthcheck::KafkaHealthcheckOps;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Event {
+    DepStart(&'static str),
+    DepStop(&'static str),
+    KafkaStart,
+    KafkaStop,
+    HealthcheckCreate,
+    HealthcheckPublish,
+    HealthcheckConsume,
+    HealthcheckDelete,
+}
+
+struct FakeKafkaImpl {
+    bootstrap: Option<String>,
+    events: Arc<Mutex<Vec<Event>>>,
+}
+
+#[async_trait]
+impl KafkaImpl for FakeKafkaImpl {
+    async fn start(&mut self, _port: u16, _image_tag: &str, _container_name: &str) {
+        self.events.lock().unwrap().push(Event::KafkaStart);
+    }
+
+    async fn stop(&mut self) {
+        self.events.lock().unwrap().push(Event::KafkaStop);
+    }
+
+    fn bootstrap_servers(&self) -> Option<&str> {
+        self.bootstrap.as_deref()
+    }
+}
+
+struct FakeOps {
+    events: Arc<Mutex<Vec<Event>>>,
+}
+
+#[async_trait]
+impl KafkaHealthcheckOps for FakeOps {
+    async fn create_topic(&self, _bootstrap: &str, _topic: &str) -> Result<(), String> {
+        self.events.lock().unwrap().push(Event::HealthcheckCreate);
+        Ok(())
+    }
+
+    async fn delete_topic(&self, _bootstrap: &str, _topic: &str) -> Result<(), String> {
+        self.events.lock().unwrap().push(Event::HealthcheckDelete);
+        Ok(())
+    }
+
+    async fn publish(&self, _bootstrap: &str, _topic: &str, _payload: &str) -> Result<(), String> {
+        self.events.lock().unwrap().push(Event::HealthcheckPublish);
+        Ok(())
+    }
+
+    async fn consume_verify(
+        &self,
+        _bootstrap: &str,
+        _topic: &str,
+        _expected_payload: &str,
+    ) -> Result<bool, String> {
+        self.events.lock().unwrap().push(Event::HealthcheckConsume);
+        Ok(true)
+    }
+}
+
+struct FakeDep {
+    name: &'static str,
+    events: Arc<Mutex<Vec<Event>>>,
+    stopped: bool,
+}
+
+#[async_trait]
+impl RunnableDependency for FakeDep {
+    fn identifier(&self) -> &str {
+        self.name
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
+    async fn start(&mut self) {
+        self.events.lock().unwrap().push(Event::DepStart(self.name));
+    }
+
+    async fn stop(&mut self) {
+        if self.stopped {
+            return;
+        }
+        self.events.lock().unwrap().push(Event::DepStop(self.name));
+        self.stopped = true;
+    }
+
+    fn add_child(&mut self, _dep: Box<dyn RunnableDependency>) {}
+}
+
+#[tokio::test]
+async fn kafka_dependency_lifecycle() {
+    let events = Arc::new(Mutex::new(Vec::<Event>::new()));
+
+    let deps: Vec<Box<dyn RunnableDependency>> = vec![
+        Box::new(FakeDep {
+            name: "dep-a",
+            events: events.clone(),
+            stopped: false,
+        }),
+        Box::new(FakeDep {
+            name: "dep-b",
+            events: events.clone(),
+            stopped: false,
+        }),
+    ];
+
+    let mut kafka = KafkaDependency {
+        identifier: "kafka".to_string(),
+        kafka_impl: Box::new(FakeKafkaImpl {
+            bootstrap: Some("127.0.0.1:9092".to_string()),
+            events: events.clone(),
+        }),
+        port: 0,
+        dependencies: Some(deps),
+        running: false,
+        image_tag: "x".to_string(),
+        container_name: Some("kafka-test".to_string()),
+        healthcheck_ops: Box::new(FakeOps {
+            events: events.clone(),
+        }),
+    };
+
+    kafka.start().await;
+    kafka.stop().await;
+
+    let got = events.lock().unwrap().clone();
+    assert_eq!(
+        got,
+        vec![
+            Event::DepStart("dep-a"),
+            Event::DepStart("dep-b"),
+            Event::KafkaStart,
+            Event::HealthcheckCreate,
+            Event::HealthcheckPublish,
+            Event::HealthcheckConsume,
+            Event::HealthcheckDelete,
+            Event::KafkaStop,
+            Event::DepStop("dep-b"),
+            Event::DepStop("dep-a"),
+        ]
+    );
+}
+

--- a/arena-kafka/src/lib.rs
+++ b/arena-kafka/src/lib.rs
@@ -1,6 +1,6 @@
 pub mod kafka_dependency;
 pub mod builder;
-mod kafka_container_impl;
 
 pub use crate::kafka_dependency::KafkaDependency;
 pub use crate::builder::KafkaFlavor;
+pub use crate::kafka_dependency::KafkaImpl;

--- a/arena-kafka/tests/component_test.rs
+++ b/arena-kafka/tests/component_test.rs
@@ -1,0 +1,169 @@
+use arena::dependency::RunnableDependency;
+use arena_kafka::{KafkaDependency, KafkaFlavor};
+use futures::FutureExt;
+use rdkafka::admin::{AdminClient, AdminOptions, NewTopic, TopicReplication};
+use rdkafka::config::ClientConfig;
+use rdkafka::consumer::{BaseConsumer, Consumer};
+use rdkafka::message::Message;
+use rdkafka::producer::{FutureProducer, FutureRecord};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+struct TestContext {
+    kafka: KafkaDependency,
+    bootstrap: String,
+    admin: AdminClient<rdkafka::client::DefaultClientContext>,
+    topic: String,
+}
+
+impl TestContext {
+    async fn new() -> Result<Self, String> {
+        let mut kafka = KafkaDependency::builder("arena-kafka component test")
+            .with_flavor(KafkaFlavor::ApacheNative)
+            .build();
+
+        kafka.start().await;
+
+        let bootstrap = match kafka.bootstrap_servers() {
+            Some(v) => v.to_string(),
+            None => {
+                kafka.stop().await;
+                return Err("kafka bootstrap servers missing after start()".to_string());
+            }
+        };
+
+        let admin: AdminClient<_> = match ClientConfig::new()
+            .set("bootstrap.servers", &bootstrap)
+            .create()
+        {
+            Ok(v) => v,
+            Err(e) => {
+                kafka.stop().await;
+                return Err(format!("create kafka admin client failed: {e}"));
+            }
+        };
+
+        let ts = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis();
+
+        let topic = format!("arena_component_test_{ts}");
+
+        Ok(Self {
+            kafka,
+            bootstrap,
+            admin,
+            topic,
+        })
+    }
+
+    async fn create_topic(&self) -> Result<(), String> {
+        let new_topic = NewTopic::new(&self.topic, 1, TopicReplication::Fixed(1));
+        let opts = AdminOptions::new().operation_timeout(Some(Duration::from_secs(5)));
+
+        let results = self
+            .admin
+            .create_topics([&new_topic], &opts)
+            .await
+            .map_err(|e| format!("create topic request failed: {e}"))?;
+
+        for r in results {
+            if let Err((_t, e)) = r {
+                return Err(format!("create topic failed: {e}"));
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn delete_topic_best_effort(&self) {
+        let opts = AdminOptions::new().operation_timeout(Some(Duration::from_secs(5)));
+        let _ = self
+            .admin
+            .delete_topics(&[self.topic.as_str()], &opts)
+            .await;
+    }
+
+    async fn stop(mut self) {
+        self.kafka.stop().await;
+    }
+}
+
+#[tokio::test]
+async fn kafka_dependency_component_happy_path_pub_sub() {
+    let _ = env_logger::builder().is_test(true).try_init();
+    let ctx = match TestContext::new().await {
+        Ok(v) => v,
+        Err(e) => panic!("{e}"),
+    };
+
+    let test_body = {
+        let ctx_ref = &ctx;
+        let bootstrap = ctx.bootstrap.clone();
+        let topic = ctx.topic.clone();
+
+        async move {
+            ctx_ref.create_topic().await?;
+
+            let ts = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_millis();
+            let actual_payload = format!("hello-from-component-test-{ts}");
+
+            let producer: FutureProducer = ClientConfig::new()
+                .set("bootstrap.servers", &bootstrap)
+                .set("message.timeout.ms", "5000")
+                .create()
+                .map_err(|e| format!("create kafka producer failed: {e}"))?;
+
+            let record = FutureRecord::to(&topic)
+                .key("component-test")
+                .payload(&actual_payload);
+            producer
+                .send(record, Duration::from_secs(5))
+                .await
+                .map_err(|(e, _msg)| format!("produce failed: {e}"))?;
+
+            let consumer: BaseConsumer = ClientConfig::new()
+                .set("bootstrap.servers", &bootstrap)
+                .set("group.id", format!("arena-component-test-{ts}"))
+                .set("enable.auto.commit", "false")
+                .set("auto.offset.reset", "earliest")
+                .create()
+                .map_err(|e| format!("create kafka consumer failed: {e}"))?;
+
+            consumer
+                .subscribe(&[&topic])
+                .map_err(|e| format!("subscribe failed: {e}"))?;
+
+            let deadline = std::time::Instant::now() + Duration::from_secs(10);
+            while std::time::Instant::now() < deadline {
+                match consumer.poll(Duration::from_millis(250)) {
+                    None => {}
+                    Some(Err(e)) => return Err(format!("consume failed: {e}")),
+                    Some(Ok(msg)) => {
+                        if let Some(bytes) = msg.payload() {
+                            if bytes == actual_payload.as_bytes() {
+                                return Ok(());
+                            }
+                        }
+                    }
+                }
+            }
+
+            Err("did not observe produced message before timeout".to_string())
+        }
+    };
+
+    let outcome = std::panic::AssertUnwindSafe(test_body).catch_unwind().await;
+
+    ctx.delete_topic_best_effort().await;
+    ctx.stop().await;
+
+    match outcome {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => panic!("{e}"),
+        Err(panic_payload) => std::panic::resume_unwind(panic_payload),
+    }
+}

--- a/arena-postgres/Cargo.toml
+++ b/arena-postgres/Cargo.toml
@@ -11,6 +11,6 @@ arena = { workspace = true }
 async-trait = { workspace = true }
 testcontainers-modules = { workspace = true, features = ["postgres"] }
 log = { workspace = true }
-postgres = "0.19"
+postgres = { workspace = true }
 futures = { workspace = true }
 backon = { workspace = true }

--- a/arena-postgres/src/builder.rs
+++ b/arena-postgres/src/builder.rs
@@ -11,7 +11,8 @@ pub struct PostgresDependencyBuilder {
     database_password: Option<String>,
     startup_sql_scripts: Option<Vec<String>>,
     dependencies: Option<Vec<Box<dyn RunnableDependency>>>,
-    container_tag: Option<String>
+    image_tag: Option<String>,
+    container_name: Option<String>,
 }
 
 impl PostgresDependencyBuilder {
@@ -20,7 +21,7 @@ impl PostgresDependencyBuilder {
     const DEFAULT_DATABASE_NAME: &'static str = "arena_db";
     const DEFAULT_DATABASE_USERNAME: &'static str = "arena_user";
     const DEFAULT_DATABASE_PASSWORD: &'static str = "postgres";
-    const DEFAULT_CONTAINER_TAG: &'static str = "latest";
+    const DEFAULT_IMAGE_TAG: &'static str = "latest";
 
     pub(crate) fn new(identifier: impl Into<String>) -> Self {
         Self {
@@ -32,7 +33,8 @@ impl PostgresDependencyBuilder {
             database_password: None,
             startup_sql_scripts: None,
             dependencies: None,
-            container_tag: None
+            image_tag: None,
+            container_name: None,
         }
     }
 
@@ -80,10 +82,24 @@ impl PostgresDependencyBuilder {
         self
     }
 
-    pub fn with_container_tag(mut self, container_tag: impl Into<String>) -> Self
-    {
-        self.container_tag = Option::from(container_tag.into());
+    pub fn with_image_tag(mut self, image_tag: impl Into<String>) -> Self {
+        self.image_tag = Some(image_tag.into());
         self
+    }
+
+    // Convenience alias.
+    pub fn with_image(self, image_tag: impl Into<String>) -> Self {
+        self.with_image_tag(image_tag)
+    }
+
+    pub fn with_container_name(mut self, container_name: impl Into<String>) -> Self {
+        self.container_name = Some(container_name.into());
+        self
+    }
+
+    // Back-compat: old name was misleading; keep it as an alias for image tag.
+    pub fn with_container_tag(self, image_tag: impl Into<String>) -> Self {
+        self.with_image_tag(image_tag)
     }
 
     pub fn build(self) -> PostgresDependency {
@@ -103,9 +119,10 @@ impl PostgresDependencyBuilder {
             .unwrap_or_else(|| Self::DEFAULT_DATABASE_PASSWORD.to_string());
         let startup_sql_scripts = self.startup_sql_scripts;
         let dependencies = self.dependencies;
-        let container_tag = self
-            .container_tag
-            .unwrap_or_else(|| Self::DEFAULT_CONTAINER_TAG.to_string());
+        let image_tag = self
+            .image_tag
+            .unwrap_or_else(|| Self::DEFAULT_IMAGE_TAG.to_string());
+        let container_name = self.container_name;
     
         PostgresDependency::new(
             self.identifier,
@@ -116,7 +133,8 @@ impl PostgresDependencyBuilder {
             database_password,
             startup_sql_scripts,
             dependencies,
-            container_tag
+            image_tag,
+            container_name,
         )
     }
 }

--- a/arena-postgres/src/postgres_container_impl.rs
+++ b/arena-postgres/src/postgres_container_impl.rs
@@ -12,7 +12,8 @@ pub trait PostgresImpl: Send + Sync {
         database_name: &str,
         database_username: &str,
         database_password: &str,
-        container_tag: &str
+        image_tag: &str,
+        container_name: &str,
     );
     async fn stop(&mut self);
 
@@ -38,7 +39,8 @@ impl PostgresImpl for PostgresContainerImpl {
         database_name: &str,
         database_username: &str,
         database_password: &str,
-        container_tag: &str
+        image_tag: &str,
+        container_name: &str,
     ) {
         if self.container.is_some() {
             return;
@@ -51,7 +53,6 @@ impl PostgresImpl for PostgresContainerImpl {
         ))
         .with_interval(Duration::from_millis(250))
         .with_timeout(Duration::from_secs(1))
-        // 10s / 250ms = 40 attempts (ish)
         .with_retries(40u32);
 
         let container = postgres::Postgres::default()
@@ -60,7 +61,8 @@ impl PostgresImpl for PostgresContainerImpl {
             .with_password(database_password)
             .with_mapped_port(port, ContainerPort::from(DEFAULT_CONTAINER_PORT))
             .with_health_check(healthcheck)
-            .with_container_name(container_tag)
+            .with_tag(image_tag)
+            .with_container_name(container_name)
             .start()
             .await
             .expect("start postgres container");

--- a/arena-postgres/src/postgres_dependency.rs
+++ b/arena-postgres/src/postgres_dependency.rs
@@ -4,7 +4,7 @@ use crate::builder::PostgresDependencyBuilder;
 use crate::postgres_container_impl::PostgresImpl;
 use backon::{BlockingRetryable, ConstantBuilder};
 use futures::channel::oneshot;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 pub struct PostgresDependency {
     pub identifier: String,
@@ -16,7 +16,8 @@ pub struct PostgresDependency {
     startup_sql_scripts: Option<Vec<String>>,
     dependencies: Option<Vec<Box<dyn RunnableDependency>>>,
     running: bool,
-    container_tag: String
+    image_tag: String,
+    container_name: Option<String>,
 }
 
 impl PostgresDependency {
@@ -29,7 +30,8 @@ impl PostgresDependency {
         database_password: String,
         startup_sql_scripts: Option<Vec<String>>,
         dependencies: Option<Vec<Box<dyn RunnableDependency>>>,
-        container_tag: String
+        image_tag: String,
+        container_name: Option<String>,
     ) -> Self {
         Self {
             identifier,
@@ -40,9 +42,29 @@ impl PostgresDependency {
             database_password,
             startup_sql_scripts,
             dependencies,
-            container_tag,
+            image_tag,
+            container_name,
             running: false,
         }
+    }
+
+    fn default_container_name(&self) -> String {
+        let mut safe = String::with_capacity(self.identifier.len());
+        for c in self.identifier.chars() {
+            let c = c.to_ascii_lowercase();
+            if c.is_ascii_alphanumeric() {
+                safe.push(c);
+            } else {
+                safe.push('-');
+            }
+        }
+
+        let ts = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis();
+
+        format!("arena-postgres-{safe}-{ts}")
     }
 
     pub fn connection_string(&self) -> Option<&str> {
@@ -203,6 +225,18 @@ impl PostgresDependency {
 
 #[async_trait]
 impl RunnableDependency for PostgresDependency {
+    fn identifier(&self) -> &str {
+        &self.identifier
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
     async fn start(&mut self) {
         if self.running {
             return;
@@ -219,7 +253,11 @@ impl RunnableDependency for PostgresDependency {
         let database_name = self.database_name.clone();
         let database_username = self.database_username.clone();
         let database_password = self.database_password.clone();
-        let container_tag = self.container_tag.clone();
+        let image_tag = self.image_tag.clone();
+        let container_name = self
+            .container_name
+            .clone()
+            .unwrap_or_else(|| self.default_container_name());
 
         let sw_container = Instant::now();
         self.postgres_impl
@@ -228,7 +266,8 @@ impl RunnableDependency for PostgresDependency {
                 &database_name,
                 &database_username,
                 &database_password,
-                &container_tag
+                &image_tag,
+                &container_name,
             )
             .await;
         log::debug!(

--- a/arena/src/arena.rs
+++ b/arena/src/arena.rs
@@ -41,6 +41,30 @@ impl ClosedArena {
     }
 }
 impl OpenArena {
+    pub fn dependency(
+        &self,
+        identifier: &str,
+    ) -> Option<&(dyn crate::dependency::RunnableDependency + '_)> {
+        for e in &self.encounters {
+            if let Some(d) = e.dependency(identifier) {
+                return Some(d);
+            }
+        }
+        None
+    }
+
+    pub fn dependency_mut(
+        &mut self,
+        identifier: &str,
+    ) -> Option<&mut (dyn crate::dependency::RunnableDependency + '_)> {
+        for e in &mut self.encounters {
+            if let Some(d) = e.dependency_mut(identifier) {
+                return Some(d);
+            }
+        }
+        None
+    }
+
     pub async fn close(mut self) -> ClosedArena {
         log::info!("[Arena-{}] closing.", self.name);
         let sw = Instant::now();
@@ -58,7 +82,6 @@ impl OpenArena {
 
         self.closed = true;
 
-        // transfer ownership between arenas
         let name = std::mem::take(&mut self.name);
         let encounters = std::mem::take(&mut self.encounters);
 

--- a/arena/src/component.rs
+++ b/arena/src/component.rs
@@ -1,45 +1,88 @@
-pub enum Component {
-    Application(ManagedProcessComponent),
+use async_trait::async_trait;
+
+#[async_trait]
+pub trait RunnableComponent: Send + Sync {
+    async fn start(&mut self);
+    async fn stop(&mut self);
+    fn add_child(&mut self, child: Box<dyn RunnableComponent>);
 }
 
-impl Component {
-    pub fn start(&self) {
-        match self {
-            Component::Application(comp) => comp.start(),
-        }
-    }
-    pub fn stop(&mut self) {
-        match self {
-            Component::Application(comp) => comp.stop(),
-        }
-    }
-}
+pub type Component = Box<dyn RunnableComponent>;
 
-pub struct ManagedProcessComponent {
+pub struct ExecutableComponentBuilder {
     endpoint: String,
+    children: Option<Vec<Component>>,
+}
+
+impl ExecutableComponentBuilder {
+    pub(crate) fn new(endpoint: impl Into<String>) -> Self {
+        Self {
+            endpoint: endpoint.into(),
+            children: None,
+        }
+    }
+
+    pub fn with_child_components(mut self, children: Vec<Component>) -> Self {
+        self.children = Some(children);
+        self
+    }
+
+    pub fn build(self) -> ExecutableComponent {
+        ExecutableComponent {
+            endpoint: self.endpoint,
+            children: self.children,
+            stopped: false,
+        }
+    }
+}
+
+pub struct ExecutableComponent {
+    endpoint: String,
+    children: Option<Vec<Box<dyn RunnableComponent>>>,
     stopped: bool,
 }
 
-impl ManagedProcessComponent {
+impl ExecutableComponent {
     pub fn new(endpoint: String) -> Self {
-        ManagedProcessComponent { endpoint, stopped: false }
+        ExecutableComponent {
+            endpoint,
+            children: None,
+            stopped: false,
+        }
     }
 
-    pub fn start(&self) {
+    pub fn builder(endpoint: impl Into<String>) -> ExecutableComponentBuilder {
+        ExecutableComponentBuilder::new(endpoint)
+    }
+}
+
+#[async_trait]
+impl RunnableComponent for ExecutableComponent {
+    async fn start(&mut self) {
+        for child in self.children.iter_mut().flatten() {
+            child.start().await;
+        }
+
         log::info!("[Component-{}] starting.", self.endpoint);
         log::info!("[Component-{}] started.", self.endpoint);
     }
 
-    pub fn stop(&mut self) {
-        if self.stopped { return; }
+    async fn stop(&mut self) {
+        if self.stopped {
+            return;
+        }
+
         log::info!("[Component-{}] stopping.", self.endpoint);
         log::info!("[Component-{}] stopped.", self.endpoint);
+
+        for child in self.children.iter_mut().flatten().rev() {
+            child.stop().await;
+        }
+
         self.stopped = true;
     }
-}
 
-impl Drop for ManagedProcessComponent {
-    fn drop(&mut self) {
-        self.stop();
+    fn add_child(&mut self, child: Box<dyn RunnableComponent>) {
+        self.children.get_or_insert_with(Vec::new).push(child);
     }
 }

--- a/arena/src/dependency.rs
+++ b/arena/src/dependency.rs
@@ -1,7 +1,11 @@
 use async_trait::async_trait;
+use std::any::Any;
 
 #[async_trait]
 pub trait RunnableDependency: Send + Sync {
+    fn identifier(&self) -> &str;
+    fn as_any(&self) -> &dyn Any;
+    fn as_any_mut(&mut self) -> &mut dyn Any;
     async fn start(&mut self);
     async fn stop(&mut self);
     fn add_child(&mut self, dep: Box<dyn RunnableDependency>);

--- a/arena/src/encounter.rs
+++ b/arena/src/encounter.rs
@@ -1,5 +1,6 @@
 use super::component::Component;
 use super::dependency::Dependency;
+use super::dependency::RunnableDependency;
 use async_trait::async_trait;
 use futures::future::join_all;
 use std::time::Instant;
@@ -8,6 +9,14 @@ use std::time::Instant;
 pub trait EncounterTrait: Send + Sync {
     async fn start(&mut self);
     async fn stop(&mut self);
+
+    fn dependency(&self, _identifier: &str) -> Option<&(dyn RunnableDependency + '_)> {
+        None
+    }
+
+    fn dependency_mut(&mut self, _identifier: &str) -> Option<&mut (dyn RunnableDependency + '_)> {
+        None
+    }
 }
 
 pub struct Encounter {
@@ -49,8 +58,8 @@ impl EncounterTrait for Encounter {
         started.sort_by_key(|(i, _)| *i);
         self.dependencies = started.into_iter().map(|(_, dep)| dep).collect();
 
-        for comp in self.components.iter() {
-            comp.start();
+        for comp in self.components.iter_mut() {
+            comp.start().await;
         }
 
         log::debug!(
@@ -71,7 +80,7 @@ impl EncounterTrait for Encounter {
         let sw = Instant::now();
 
         for comp in self.components.iter_mut().rev() {
-            comp.stop();
+            comp.stop().await;
         }
 
         let deps = std::mem::take(&mut self.dependencies);
@@ -92,5 +101,21 @@ impl EncounterTrait for Encounter {
         );
         log::info!("[Encounters-{}] stopped.", self.name);
         self.started = false;
+    }
+
+    fn dependency(&self, identifier: &str) -> Option<&(dyn RunnableDependency + '_)> {
+        self.dependencies
+            .iter()
+            .map(|d| d.as_ref())
+            .find(|d| d.identifier() == identifier)
+    }
+
+    fn dependency_mut(&mut self, identifier: &str) -> Option<&mut (dyn RunnableDependency + '_)> {
+        for dep in &mut self.dependencies {
+            if dep.identifier() == identifier {
+                return Some(dep.as_mut());
+            }
+        }
+        None
     }
 }

--- a/arena/src/lib.rs
+++ b/arena/src/lib.rs
@@ -5,5 +5,5 @@ pub mod encounter;
 
 pub use crate::arena::ClosedArena;
 pub use crate::encounter::{Encounter, EncounterTrait};
-pub use crate::component::{Component, ManagedProcessComponent};
+pub use crate::component::{Component, ExecutableComponent, RunnableComponent};
 pub use crate::dependency::Dependency;

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -10,6 +10,12 @@ license = "BSD-3-Clause"
 arena = { workspace = true }
 arena-kafka = { workspace = true }
 arena-postgres = { workspace = true }
-tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal", "net", "sync"] }
 env_logger = { workspace = true }
 log = { workspace = true }
+axum = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio-postgres = { workspace = true }
+rdkafka = { workspace = true }
+futures = { workspace = true }

--- a/examples/src/main.rs
+++ b/examples/src/main.rs
@@ -1,48 +1,309 @@
-use arena::{ClosedArena, Encounter, EncounterTrait, Component, ManagedProcessComponent, Dependency};
+use arena::{ClosedArena, Component, Dependency, Encounter, EncounterTrait, ExecutableComponent};
 use arena_kafka::{KafkaDependency, KafkaFlavor};
 use arena_postgres::PostgresDependency;
+use axum::{
+    extract::State,
+    http::StatusCode,
+    routing::{get},
+    Json, Router,
+};
 use env_logger::Env;
+use serde::{Deserialize, Serialize};
+use rdkafka::config::ClientConfig;
+use rdkafka::consumer::{Consumer, StreamConsumer};
+use rdkafka::message::Message;
+use rdkafka::producer::{FutureProducer, FutureRecord};
+use futures::StreamExt;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio_postgres::{Client, NoTls};
+use axum::body::Body;
+use axum::http::Request;
+use axum::middleware::Next;
+use axum::response::Response;
+use std::time::Instant;
+
+#[derive(Clone)]
+struct AppState {
+    pg: Arc<Client>,
+    kafka: FutureProducer,
+    kafka_topic: Arc<str>,
+}
+
+#[derive(Deserialize)]
+struct CreateReadingRequest {
+    user_name: String,
+    value: i32,
+    comment: Option<String>,
+}
+
+#[derive(Serialize)]
+struct CreateReadingResponse {
+    id: i64,
+}
+
+#[derive(Serialize)]
+struct ReadingRow {
+    id: i64,
+    user_name: String,
+    value: i32,
+    comment: Option<String>,
+}
+
+#[derive(Serialize)]
+struct ReadingCreatedEvent<'a> {
+    id: i64,
+    user_name: &'a str,
+    value: i32,
+    comment: &'a Option<String>,
+}
+
+async fn health() -> &'static str {
+    "ok"
+}
+
+async fn log_requests(req: Request<Body>, next: Next) -> Response {
+    let method = req.method().clone();
+    let uri = req.uri().clone();
+    let sw = Instant::now();
+
+    let res = next.run(req).await;
+
+    log::debug!("{} {} -> {} in {:?}", method, uri, res.status(), sw.elapsed());
+    res
+}
+
+async fn list_readings(
+    State(st): State<AppState>,
+) -> Result<Json<Vec<ReadingRow>>, (StatusCode, String)> {
+    let rows = st
+        .pg
+        .query(
+            r#"
+            select r.id, u.name, r.value, r.comment
+            from instrument_reading.reading r
+            join instrument_reading."user" u on u.id = r."userId"
+            order by r.id desc
+            limit 50
+            "#,
+            &[],
+        )
+        .await
+        .map_err(internal_error)?;
+
+    let out = rows
+        .into_iter()
+        .map(|r| ReadingRow {
+            id: r.get::<_, i64>(0),
+            user_name: r.get::<_, String>(1),
+            value: r.get::<_, i32>(2),
+            comment: r.get::<_, Option<String>>(3),
+        })
+        .collect();
+
+    Ok(Json(out))
+}
+
+async fn create_reading(
+    State(st): State<AppState>,
+    Json(req): Json<CreateReadingRequest>,
+) -> Result<(StatusCode, Json<CreateReadingResponse>), (StatusCode, String)> {
+    let user_id: i64 = match st
+        .pg
+        .query_opt(
+            r#"select id from instrument_reading."user" where name = $1"#,
+            &[&req.user_name],
+        )
+        .await
+        .map_err(internal_error)?
+    {
+        Some(row) => row.get(0),
+        None => {
+            let row = st
+                .pg
+                .query_one(
+                    r#"insert into instrument_reading."user"(name) values ($1) returning id"#,
+                    &[&req.user_name],
+                )
+                .await
+                .map_err(internal_error)?;
+            row.get(0)
+        }
+    };
+
+    let row = st
+        .pg
+        .query_one(
+            r#"
+            insert into instrument_reading.reading("userId", value, comment)
+            values ($1, $2, $3)
+            returning id
+            "#,
+            &[&user_id, &req.value, &req.comment],
+        )
+        .await
+        .map_err(internal_error)?;
+
+    let id: i64 = row.get(0);
+
+    let payload = serde_json::to_string(&ReadingCreatedEvent {
+        id,
+        user_name: &req.user_name,
+        value: req.value,
+        comment: &req.comment,
+    })
+    .map_err(internal_error)?;
+
+    let key = id.to_string();
+    let record = FutureRecord::to(&st.kafka_topic)
+        .key(&key)
+        .payload(&payload);
+    if let Err((e, _msg)) = st.kafka.send(record, Duration::from_secs(2)).await {
+        log::debug!("kafka publish failed: {e}");
+    }
+
+    Ok((StatusCode::CREATED, Json(CreateReadingResponse { id })))
+}
+
+fn internal_error<E: std::fmt::Display>(e: E) -> (StatusCode, String) {
+    (StatusCode::INTERNAL_SERVER_ERROR, e.to_string())
+}
 
 #[tokio::main]
 async fn main() {
     env_logger::Builder::from_env(
         Env::default().default_filter_or(
-            "arena=debug,arena_postgres=debug,arena_kafka=debug,testcontainers=info,testcontainers_modules=info",
+            "arena=debug,arena_examples=debug,arena_postgres=debug,arena_kafka=debug,testcontainers=info,testcontainers_modules=info",
         ),
     )
     .init();
 
-    let startup_sql_scripts = vec![
-        include_str!("../resources/instrument_reading_db_schema.sql").to_string(),
-    ];
+    let postgres_port = 4444u16;
+    let db_name = "my_database";
+    let db_user = "my_user";
+    let db_pass = "my_password";
+
+    let startup_sql_scripts =
+        vec![include_str!("../resources/instrument_reading_db_schema.sql").to_string()];
 
     let postgres_db: Dependency = Box::new(
         PostgresDependency::builder("arena example database")
-            .with_container_tag("14.20-trixie")
-            .with_port(4444)
-            .with_database_name("my_database")
-            .with_database_username("my_user")
-            .with_database_password("my_password")
+            .with_image("14.20-trixie")
+            .with_port(postgres_port)
+            .with_database_name(db_name)
+            .with_database_username(db_user)
+            .with_database_password(db_pass)
             .with_startup_sql_scripts(startup_sql_scripts)
-            .build());
+            .build(),
+    );
 
     let kafka: Dependency = Box::new(
-        KafkaDependency::builder("kafka custom dependency name")
+        KafkaDependency::builder("arena example kafka")
             .with_flavor(KafkaFlavor::ApacheNative)
-            .build()
+            .build(),
     );
 
     let dependencies: Vec<Dependency> = vec![postgres_db, kafka];
 
-    let components: Vec<Component> = vec![
-        Component::Application(ManagedProcessComponent::new("web app".to_string())),
-    ];
+    let components: Vec<Component> = vec![Box::new(
+        ExecutableComponent::builder("arena example web app").build(),
+    )];
 
     let encounter = Encounter::new("End to end happy path", dependencies, components);
     let encounters: Vec<Box<dyn EncounterTrait>> = vec![Box::new(encounter)];
-
     let closed = ClosedArena::new(String::from("Example Arena"), encounters);
 
     let open = closed.open().await;
+
+    let kafka_bootstrap = open
+        .dependency("arena example kafka")
+        .and_then(|d| d.as_any().downcast_ref::<KafkaDependency>())
+        .and_then(|k| k.bootstrap_servers())
+        .expect("kafka dependency bootstrap should be available after open()")
+        .to_string();
+
+    let conn_str = open
+        .dependency("arena example database")
+        .and_then(|d| d.as_any().downcast_ref::<PostgresDependency>())
+        .and_then(|p| p.connection_string())
+        .expect("postgres dependency connection string should be available after open()")
+        .to_string();
+
+    let (pg, connection) = tokio_postgres::connect(&conn_str, NoTls)
+        .await
+        .expect("connect to postgres");
+    tokio::spawn(async move {
+        if let Err(e) = connection.await {
+            log::error!("postgres connection error: {e}");
+        }
+    });
+
+    let kafka_topic: Arc<str> = Arc::from("readings");
+
+    let kafka: FutureProducer = ClientConfig::new()
+        .set("bootstrap.servers", &kafka_bootstrap)
+        .set("message.timeout.ms", "5000")
+        .create()
+        .expect("create kafka producer");
+
+    let consumer: StreamConsumer = ClientConfig::new()
+        .set("bootstrap.servers", &kafka_bootstrap)
+        .set("group.id", "arena-examples")
+        .set("enable.partition.eof", "false")
+        .set("auto.offset.reset", "earliest")
+        .create()
+        .expect("create kafka consumer");
+    consumer
+        .subscribe(&[kafka_topic.as_ref()])
+        .expect("subscribe");
+
+    let consumer_topic = kafka_topic.clone();
+    tokio::spawn(async move {
+        let mut stream = consumer.stream();
+        while let Some(result) = stream.next().await {
+            match result {
+                Ok(msg) => {
+                    let payload = msg
+                        .payload_view::<str>()
+                        .and_then(|r| r.ok())
+                        .unwrap_or("");
+                    log::debug!("kafka {}: {}", consumer_topic.as_ref(), payload);
+                }
+                Err(err) => {
+                    log::debug!("kafka consume error: {err}");
+                }
+            }
+        }
+    });
+
+    let app = Router::new()
+        .route("/health", get(health))
+        .route("/readings", get(list_readings).post(create_reading))
+        .layer(axum::middleware::from_fn(log_requests))
+        .with_state(AppState {
+            pg: Arc::new(pg),
+            kafka,
+            kafka_topic,
+        });
+
+    let addr: SocketAddr = "127.0.0.1:3000".parse().unwrap();
+    let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
+    log::info!("listening on http://{addr}");
+
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+    let server = tokio::spawn(async move {
+        axum::serve(listener, app)
+            .with_graceful_shutdown(async {
+                let _ = shutdown_rx.await;
+            })
+            .await
+            .unwrap();
+    });
+
+    tokio::signal::ctrl_c().await.unwrap();
+    let _ = shutdown_tx.send(());
+    let _ = server.await;
+
     let _closed = open.close().await;
 }


### PR DESCRIPTION
- Refactored component to follow same RunnableComponent pattern as Dependency. 
- Renamed ProcessComponent. 
- Added better healthcheck to kafka depdendncy. Restructured kafka files and added unit and component lifecycle test.
- Added areana api to get dependency using identifier and implmented for kafka and postgres. 
- Added a simple axum web server and basic endpoints in example. DB and kafka integration.