### PR TITLE
Run dependency review on push to master, not just PRs

### DIFF
--- a/.github/workflows/build-test-publish-arena.yml
+++ b/.github/workflows/build-test-publish-arena.yml
@@ -49,7 +49,7 @@ jobs:
               .codecov.yml|LICENSE) return 0 ;;
               *.png) return 0 ;;
             esac
-            [[ "$1" == .cursor/* || "$1" == .idea/* || "$1" == .vscode/* ]]
+            [[ "$1" == .cursor/* || "$1" == .idea/* || "$1" == .vscode/* || "$1" == .github/workflows/* ]]
           }
           only_non_publishable=false
           has_publishable=false

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -3,6 +3,8 @@ name: Dependency Review
 on:
   pull_request:
     branches: [master]
+  push:
+    branches: [master]
 
 permissions:
   contents: read
@@ -14,7 +16,11 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          fetch-depth: 2
 
       - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48
         with:
           fail-on-severity: moderate
+          base-ref: ${{ github.event_name == 'push' && 'HEAD~1' || '' }}
+          head-ref: ${{ github.event_name == 'push' && 'HEAD' || '' }}


### PR DESCRIPTION
Keeps the README's branch=master status badge up to date after merges.