### PR TITLE
Add arena-smtp mail-capture dependency crate

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "82a65bf8bb975a3f57a32c317533509e55e877fb6a371b6c3b46f7757977e93e",
+  "checksum": "df0919b7e1278caf27bd36819e7951d171ea360b61e50f6573da4428cd3b1dc1",
   "crates": {
     "adler2 2.0.1": {
       "name": "adler2",
@@ -1352,6 +1352,84 @@
             {
               "id": "tokio 1.52.1",
               "target": "tokio"
+            },
+            {
+              "id": "tracing-subscriber 0.3.23",
+              "target": "tracing_subscriber"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "proc_macro_deps": {
+          "common": [
+            {
+              "id": "async-trait 0.1.89",
+              "target": "async_trait"
+            }
+          ],
+          "selects": {}
+        },
+        "version": "3.3.0"
+      },
+      "license": "todo",
+      "license_ids": [],
+      "license_file": null
+    },
+    "arena-smtp 3.3.0": {
+      "name": "arena-smtp",
+      "version": "3.3.0",
+      "package_url": null,
+      "repository": null,
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "arena_smtp",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "arena_smtp",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "futures 0.3.32",
+              "target": "futures"
+            },
+            {
+              "id": "futures-timer 3.0.3",
+              "target": "futures_timer"
+            },
+            {
+              "id": "testcontainers-modules 0.15.0",
+              "target": "testcontainers_modules"
+            },
+            {
+              "id": "tokio 1.52.1",
+              "target": "tokio"
+            },
+            {
+              "id": "tracing 0.1.44",
+              "target": "tracing"
+            }
+          ],
+          "selects": {}
+        },
+        "deps_dev": {
+          "common": [
+            {
+              "id": "reqwest 0.12.28",
+              "target": "reqwest"
             },
             {
               "id": "tracing-subscriber 0.3.23",
@@ -33203,6 +33281,7 @@
     "arena-mssql 3.3.0": "arena-mssql",
     "arena-oauth 3.3.0": "arena-oauth",
     "arena-postgres 3.3.0": "arena-postgres",
+    "arena-smtp 3.3.0": "arena-smtp",
     "arena-temporal 3.3.0": "arena-temporal"
   },
   "conditions": {

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,7 +151,6 @@ dependencies = [
  "arena-mssql",
  "arena-oauth",
  "arena-postgres",
- "arena-smtp",
  "arena-temporal",
  "async-trait",
  "reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,6 +151,7 @@ dependencies = [
  "arena-mssql",
  "arena-oauth",
  "arena-postgres",
+ "arena-smtp",
  "arena-temporal",
  "async-trait",
  "reqwest",
@@ -269,6 +270,22 @@ dependencies = [
  "async-trait",
  "futures",
  "postgres",
+ "testcontainers-modules",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "arena-smtp"
+version = "3.3.0"
+dependencies = [
+ "arena",
+ "arena-container",
+ "async-trait",
+ "futures",
+ "futures-timer",
+ "reqwest",
  "testcontainers-modules",
  "tokio",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "arena-http",
     "arena-oauth",
     "arena-temporal",
+    "arena-smtp",
     "arena-executable-component",
     "arena-container",
     "arena-containerized-component",
@@ -25,6 +26,7 @@ arena-localstack = { path = "arena-localstack" }
 arena-postgres = { path = "arena-postgres" }
 arena-mssql = { path = "arena-mssql" }
 arena-temporal = { path = "arena-temporal" }
+arena-smtp = { path = "arena-smtp" }
 arena-executable-component = { path = "arena-executable-component" }
 arena-http = { path = "arena-http" }
 arena-oauth = { path = "arena-oauth" }

--- a/README.md
+++ b/README.md
@@ -97,6 +97,21 @@ open.close().await;
 
 You can also use `with_source_path` / `with_build_tool` on the builder so Arena builds the binary before starting it (see `examples/`).
 
+To test outbound email, add an SMTP mail-capture server dependency. Your app sends mail to it, and you assert on what was captured via its HTTP API:
+
+```rust
+use arena_smtp::SmtpDependency;
+
+let smtp: Dependency = Box::new(
+    SmtpDependency::builder("mail")
+        .with_port(1025)
+        .with_ui_port(8025)
+        .build(),
+);
+// After the arena is open: smtp.smtp_address() is the host:port to send to,
+// and smtp.http_api_url() is the HTTP API used to read captured messages.
+```
+
 ### Python (arena-pytest)
 
 ```python

--- a/arena-smtp/BUILD
+++ b/arena-smtp/BUILD
@@ -1,0 +1,87 @@
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
+load("@crates//:defs.bzl", "all_crate_deps")
+
+rust_library(
+    name = "arena_smtp",
+    srcs = glob(["src/**/*.rs"]),
+    edition = "2021",
+    deps = all_crate_deps(normal = True) + [
+        "//arena",
+        "//arena-container:arena_container",
+    ],
+    proc_macro_deps = all_crate_deps(proc_macro = True),
+    visibility = ["//visibility:public"],
+)
+
+rust_test(
+    name = "unit_test",
+    srcs = ["tests/unit_test.rs"],
+    size = "small",
+    edition = "2021",
+    deps = all_crate_deps(
+        normal = True,
+        normal_dev = True,
+    ) + [
+        ":arena_smtp",
+        "//arena",
+    ],
+    proc_macro_deps = all_crate_deps(
+        proc_macro = True,
+        proc_macro_dev = True,
+    ),
+)
+
+rust_test(
+    name = "drop_teardown_test",
+    srcs = ["tests/drop_teardown_test.rs"],
+    size = "small",
+    edition = "2021",
+    deps = all_crate_deps(
+        normal = True,
+        normal_dev = True,
+    ) + [
+        ":arena_smtp",
+        "//arena",
+    ],
+    proc_macro_deps = all_crate_deps(
+        proc_macro = True,
+        proc_macro_dev = True,
+    ),
+)
+
+rust_test(
+    name = "builder_test",
+    srcs = ["tests/builder_test.rs"],
+    size = "small",
+    edition = "2021",
+    deps = all_crate_deps(
+        normal = True,
+        normal_dev = True,
+    ) + [
+        ":arena_smtp",
+        "//arena",
+    ],
+    proc_macro_deps = all_crate_deps(
+        proc_macro = True,
+        proc_macro_dev = True,
+    ),
+)
+
+rust_test(
+    name = "component_test",
+    srcs = ["tests/component_test.rs"],
+    size = "medium",
+    edition = "2021",
+    tags = ["component_test"],
+    deps = all_crate_deps(
+        normal = True,
+        normal_dev = True,
+    ) + [
+        ":arena_smtp",
+        "//arena",
+    ],
+    proc_macro_deps = all_crate_deps(
+        proc_macro = True,
+        proc_macro_dev = True,
+    ),
+)

--- a/arena-smtp/BUILD
+++ b/arena-smtp/BUILD
@@ -32,6 +32,24 @@ rust_test(
 )
 
 rust_test(
+    name = "healthcheck_test",
+    srcs = ["tests/healthcheck_test.rs"],
+    size = "small",
+    edition = "2021",
+    deps = all_crate_deps(
+        normal = True,
+        normal_dev = True,
+    ) + [
+        ":arena_smtp",
+        "//arena",
+    ],
+    proc_macro_deps = all_crate_deps(
+        proc_macro = True,
+        proc_macro_dev = True,
+    ),
+)
+
+rust_test(
     name = "drop_teardown_test",
     srcs = ["tests/drop_teardown_test.rs"],
     size = "small",

--- a/arena-smtp/Cargo.toml
+++ b/arena-smtp/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "arena-smtp"
+version.workspace = true
+edition = "2021"
+authors = ["David Pope"]
+description = "Arena SMTP implementation"
+license = "todo"
+
+[dependencies]
+arena = { workspace = true }
+arena-container = { workspace = true }
+async-trait = { workspace = true }
+testcontainers-modules = { workspace = true }
+tracing = { workspace = true }
+futures = { workspace = true }
+futures-timer = { workspace = true }
+tokio = { workspace = true, features = ["macros", "net", "io-util", "time"] }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time", "net", "io-util"] }
+tracing-subscriber = { workspace = true }
+reqwest = { workspace = true }

--- a/arena-smtp/src/builder.rs
+++ b/arena-smtp/src/builder.rs
@@ -1,0 +1,131 @@
+use crate::smtp_dependency::container_impl::SmtpContainerImpl;
+use crate::smtp_dependency::{SmtpDependency, SmtpImpl};
+use arena::dependency::RunnableDependency;
+use arena::healthcheck::ReadinessCheck;
+
+pub struct SmtpDependencyBuilder {
+    identifier: String,
+    smtp_impl: Option<Box<dyn SmtpImpl>>,
+    port: Option<u16>,
+    ui_port: Option<u16>,
+    dependencies: Option<Vec<Box<dyn RunnableDependency>>>,
+    image_name: Option<String>,
+    image_tag: Option<String>,
+    container_name: Option<String>,
+    network: Option<String>,
+    readiness_check: Option<Box<dyn ReadinessCheck>>,
+}
+
+impl SmtpDependencyBuilder {
+    const DEFAULT_PORT: u16 = 1025;
+    const DEFAULT_UI_PORT: u16 = 8025;
+
+    pub(crate) fn new(identifier: impl Into<String>) -> Self {
+        Self {
+            identifier: identifier.into(),
+            smtp_impl: None,
+            port: None,
+            ui_port: None,
+            dependencies: None,
+            image_name: None,
+            image_tag: None,
+            container_name: None,
+            network: None,
+            readiness_check: None,
+        }
+    }
+
+    pub fn with_impl<W>(mut self, wrapper: W) -> Self
+    where
+        W: SmtpImpl + 'static,
+    {
+        self.smtp_impl = Some(Box::new(wrapper));
+        self
+    }
+
+    pub fn with_port(mut self, port: u16) -> Self {
+        self.port = Option::from(port);
+        self
+    }
+
+    pub fn with_ui_port(mut self, ui_port: u16) -> Self {
+        self.ui_port = Option::from(ui_port);
+        self
+    }
+
+    pub fn with_child_dependencies(
+        mut self,
+        dependencies: Vec<Box<dyn RunnableDependency>>,
+    ) -> Self {
+        self.dependencies = Option::from(dependencies);
+        self
+    }
+
+    pub fn with_image_name(mut self, image_name: impl Into<String>) -> Self {
+        self.image_name = Some(image_name.into());
+        self
+    }
+
+    pub fn with_image_tag(mut self, image_tag: impl Into<String>) -> Self {
+        self.image_tag = Some(image_tag.into());
+        self
+    }
+
+    pub fn with_image(self, image_tag: impl Into<String>) -> Self {
+        self.with_image_tag(image_tag)
+    }
+
+    pub fn with_container_name(mut self, container_name: impl Into<String>) -> Self {
+        self.container_name = Some(container_name.into());
+        self
+    }
+
+    pub fn with_network(mut self, network: impl Into<String>) -> Self {
+        self.network = Some(network.into());
+        self
+    }
+
+    pub fn with_readiness_check<W>(mut self, check: W) -> Self
+    where
+        W: ReadinessCheck + 'static,
+    {
+        self.readiness_check = Some(Box::new(check));
+        self
+    }
+
+    pub fn with_container_tag(self, image_tag: impl Into<String>) -> Self {
+        self.with_image_tag(image_tag)
+    }
+
+    pub fn build(self) -> SmtpDependency {
+        let smtp_impl = self
+            .smtp_impl
+            .unwrap_or_else(|| Box::new(SmtpContainerImpl::new(self.network)));
+
+        let port = self.port.unwrap_or(Self::DEFAULT_PORT);
+        let ui_port = self.ui_port.unwrap_or(Self::DEFAULT_UI_PORT);
+        let image_name = self
+            .image_name
+            .unwrap_or_else(|| arena_container::default_images::SMTP.image.to_string());
+        let image_tag = self
+            .image_tag
+            .unwrap_or_else(|| arena_container::default_images::SMTP.tag.to_string());
+
+        let mut dep = SmtpDependency::new(
+            arena_container::identifier::build("arena-smtp", &self.identifier),
+            smtp_impl,
+            port,
+            ui_port,
+            self.dependencies,
+            image_name,
+            image_tag,
+            self.container_name,
+        );
+
+        if let Some(check) = self.readiness_check {
+            dep.set_readiness_check(check);
+        }
+
+        dep
+    }
+}

--- a/arena-smtp/src/lib.rs
+++ b/arena-smtp/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod builder;
+pub mod smtp_dependency;
+
+pub use crate::smtp_dependency::SmtpDependency;
+pub use crate::smtp_dependency::SmtpImpl;

--- a/arena-smtp/src/smtp_dependency.rs
+++ b/arena-smtp/src/smtp_dependency.rs
@@ -1,0 +1,299 @@
+pub(crate) mod container_impl;
+mod healthcheck;
+
+use crate::builder::SmtpDependencyBuilder;
+use crate::smtp_dependency::healthcheck::DefaultSmtpReadinessCheck;
+use arena::dependency::RunnableDependency;
+use arena::healthcheck::ReadinessCheck;
+use async_trait::async_trait;
+use futures_timer::Delay;
+use std::time::{Duration, Instant};
+
+#[async_trait]
+pub trait SmtpImpl: Send + Sync {
+    async fn start(
+        &mut self,
+        smtp_port: u16,
+        ui_port: u16,
+        image_name: &str,
+        image_tag: &str,
+        container_name: &str,
+    );
+    async fn stop(&mut self);
+    fn smtp_address(&self) -> Option<&str>;
+    fn http_api_url(&self) -> Option<&str>;
+}
+
+pub struct SmtpDependency {
+    pub identifier: String,
+    smtp_impl: Box<dyn SmtpImpl>,
+    smtp_port: u16,
+    ui_port: u16,
+    dependencies: Option<Vec<Box<dyn RunnableDependency>>>,
+    running: bool,
+    needs_teardown: bool,
+    children_started: bool,
+    image_name: String,
+    image_tag: String,
+    container_name: Option<String>,
+    readiness_check: Box<dyn ReadinessCheck>,
+}
+
+impl SmtpDependency {
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new(
+        identifier: String,
+        smtp_impl: Box<dyn SmtpImpl>,
+        smtp_port: u16,
+        ui_port: u16,
+        dependencies: Option<Vec<Box<dyn RunnableDependency>>>,
+        image_name: String,
+        image_tag: String,
+        container_name: Option<String>,
+    ) -> Self {
+        Self {
+            identifier,
+            smtp_impl,
+            smtp_port,
+            ui_port,
+            dependencies,
+            image_name,
+            image_tag,
+            container_name,
+            running: false,
+            needs_teardown: false,
+            children_started: false,
+            readiness_check: Box::new(DefaultSmtpReadinessCheck),
+        }
+    }
+
+    pub fn smtp_address(&self) -> Option<&str> {
+        self.smtp_impl.smtp_address()
+    }
+
+    pub fn http_api_url(&self) -> Option<&str> {
+        self.smtp_impl.http_api_url()
+    }
+
+    pub fn builder(identifier: impl Into<String>) -> SmtpDependencyBuilder {
+        SmtpDependencyBuilder::new(identifier)
+    }
+
+    pub(crate) fn set_readiness_check(&mut self, check: Box<dyn ReadinessCheck>) {
+        self.readiness_check = check;
+    }
+
+    fn smtp_address_on_host(&self) -> Result<&str, String> {
+        self.smtp_address()
+            .ok_or_else(|| "smtp address not available yet".to_string())
+    }
+
+    async fn wait_until_ready(&self) {
+        let timeout = Duration::from_secs(30);
+        let poll_every = Duration::from_millis(100);
+        let start = Instant::now();
+
+        let address = loop {
+            if start.elapsed() >= timeout {
+                panic!(
+                    "[Smtp-{}] smtp did not become ready within {:?}",
+                    self.identifier, timeout
+                );
+            }
+
+            match self.smtp_address_on_host() {
+                Ok(v) => break v.to_string(),
+                Err(err) => {
+                    tracing::debug!(
+                        dependency = %self.identifier,
+                        reason = %err,
+                        "smtp address not ready yet"
+                    );
+                    Delay::new(poll_every).await;
+                }
+            }
+        };
+
+        let remaining = timeout.saturating_sub(start.elapsed());
+        if remaining.is_zero() {
+            panic!(
+                "[Smtp-{}] smtp did not become ready within {:?}",
+                self.identifier, timeout
+            );
+        }
+
+        match self
+            .readiness_check
+            .is_ready(&self.identifier, &address, remaining.as_millis() as u64)
+            .await
+        {
+            Ok(()) => {}
+            Err(err) => panic!("[Smtp-{}] readiness check failed: {}", self.identifier, err),
+        }
+    }
+}
+
+#[async_trait]
+impl RunnableDependency for SmtpDependency {
+    fn identifier(&self) -> &str {
+        &self.identifier
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
+    async fn start(&mut self) {
+        if self.running {
+            return;
+        }
+
+        tracing::debug!(dependency = %self.identifier, phase = "start_begin", "starting");
+        let sw = Instant::now();
+
+        if let Some(children) = self.dependencies.as_mut() {
+            if !children.is_empty() {
+                self.children_started = true;
+                for dep in children.iter_mut() {
+                    dep.start().await;
+                }
+            }
+        }
+
+        let image_name = self.image_name.clone();
+        let image_tag = self.image_tag.clone();
+        let container_name = arena_container::identifier::resolve_container_name(
+            &self.identifier,
+            self.container_name.as_deref(),
+        );
+
+        let sw_container = Instant::now();
+        self.needs_teardown = true;
+        self.smtp_impl
+            .start(
+                self.smtp_port,
+                self.ui_port,
+                &image_name,
+                &image_tag,
+                &container_name,
+            )
+            .await;
+        tracing::debug!(
+            dependency = %self.identifier,
+            elapsed = ?sw_container.elapsed(),
+            "container start finished"
+        );
+
+        let sw_ready = Instant::now();
+        self.wait_until_ready().await;
+        tracing::debug!(
+            dependency = %self.identifier,
+            elapsed = ?sw_ready.elapsed(),
+            "readiness wait finished"
+        );
+
+        self.running = true;
+        tracing::debug!(
+            dependency = %self.identifier,
+            elapsed = ?sw.elapsed(),
+            "started"
+        );
+    }
+
+    async fn stop(&mut self) {
+        self.smtp_impl.stop().await;
+        self.needs_teardown = false;
+
+        if !self.running {
+            if self.children_started {
+                for dep in self.dependencies.iter_mut().flatten().rev() {
+                    dep.stop().await;
+                }
+                self.children_started = false;
+            }
+            return;
+        }
+
+        tracing::debug!(dependency = %self.identifier, phase = "stop_begin", "stopping");
+        let sw = Instant::now();
+
+        for dep in self.dependencies.iter_mut().flatten().rev() {
+            dep.stop().await;
+        }
+
+        self.children_started = false;
+        self.running = false;
+        tracing::debug!(
+            dependency = %self.identifier,
+            elapsed = ?sw.elapsed(),
+            "stopped"
+        );
+    }
+
+    fn add_child(&mut self, dep: Box<dyn RunnableDependency>) {
+        self.dependencies.get_or_insert_with(Vec::new).push(dep);
+    }
+
+    async fn soft_reset(&self) {
+        if !self.running {
+            return;
+        }
+
+        tracing::warn!(
+            dependency = %self.identifier,
+            "soft reset skipped: no reset primitive without an smtp client"
+        );
+    }
+
+    async fn hard_reset(&mut self) {
+        if !self.running {
+            return;
+        }
+
+        tracing::debug!(
+            dependency = %self.identifier,
+            phase = "hard_reset",
+            "restarting smtp container"
+        );
+
+        let image_name = self.image_name.clone();
+        let image_tag = self.image_tag.clone();
+        let container_name = arena_container::identifier::resolve_container_name(
+            &self.identifier,
+            self.container_name.as_deref(),
+        );
+
+        self.smtp_impl.stop().await;
+        self.running = false;
+
+        self.smtp_impl
+            .start(
+                self.smtp_port,
+                self.ui_port,
+                &image_name,
+                &image_tag,
+                &container_name,
+            )
+            .await;
+        self.wait_until_ready().await;
+        self.running = true;
+    }
+}
+
+impl Drop for SmtpDependency {
+    fn drop(&mut self) {
+        if self.running {
+            tracing::warn!(
+                dependency = %self.identifier,
+                "drop while running; forcing stop"
+            );
+            futures::executor::block_on(<Self as RunnableDependency>::stop(self));
+        } else if self.needs_teardown || self.children_started {
+            futures::executor::block_on(<Self as RunnableDependency>::stop(self));
+        }
+    }
+}

--- a/arena-smtp/src/smtp_dependency/container_impl.rs
+++ b/arena-smtp/src/smtp_dependency/container_impl.rs
@@ -1,0 +1,101 @@
+use crate::smtp_dependency::SmtpImpl;
+use async_trait::async_trait;
+use testcontainers_modules::testcontainers::core::ContainerPort;
+use testcontainers_modules::testcontainers::ImageExt;
+use testcontainers_modules::{
+    testcontainers, testcontainers::runners::AsyncRunner, testcontainers::GenericImage,
+};
+
+const SMTP_CONTAINER_PORT: u16 = 1025;
+const UI_CONTAINER_PORT: u16 = 8025;
+
+pub(crate) struct SmtpContainerImpl {
+    container: Option<testcontainers::core::ContainerAsync<GenericImage>>,
+    smtp_address: Option<String>,
+    http_api_url: Option<String>,
+    network: Option<String>,
+}
+
+impl SmtpContainerImpl {
+    pub(crate) fn new(network: Option<String>) -> Self {
+        Self {
+            container: None,
+            smtp_address: None,
+            http_api_url: None,
+            network,
+        }
+    }
+}
+
+#[async_trait]
+impl SmtpImpl for SmtpContainerImpl {
+    async fn start(
+        &mut self,
+        smtp_port: u16,
+        ui_port: u16,
+        image_name: &str,
+        image_tag: &str,
+        container_name: &str,
+    ) {
+        if self.container.is_some() {
+            return;
+        }
+
+        arena_container::container::try_remove_existing_container(container_name).await;
+
+        let smtp_container_port = ContainerPort::from(SMTP_CONTAINER_PORT);
+        let ui_container_port = ContainerPort::from(UI_CONTAINER_PORT);
+
+        let image = GenericImage::new(image_name, image_tag)
+            .with_exposed_port(smtp_container_port)
+            .with_exposed_port(ui_container_port);
+
+        let mut request = image
+            .with_container_name(container_name)
+            .with_mapped_port(smtp_port, smtp_container_port)
+            .with_mapped_port(ui_port, ui_container_port);
+
+        if let Some(ref network) = self.network {
+            arena_container::network::ensure_network_exists(network).await;
+            request = request.with_network(network);
+        }
+
+        let container = request.start().await.expect("start smtp container");
+
+        let (host, smtp_host_port, ui_host_port) = tokio::join!(
+            container.get_host(),
+            container.get_host_port_ipv4(smtp_container_port),
+            container.get_host_port_ipv4(ui_container_port),
+        );
+        let host = host.expect("Failed to get host").to_string();
+        let smtp_host_port = smtp_host_port.expect("Failed to get smtp port");
+        let ui_host_port = ui_host_port.expect("Failed to get ui port");
+
+        self.smtp_address = Some(format!("{host}:{smtp_host_port}"));
+        self.http_api_url = Some(format!("http://{host}:{ui_host_port}"));
+        self.container = Some(container);
+
+        tracing::debug!(layer = "smtp_container", phase = "container_started");
+    }
+
+    async fn stop(&mut self) {
+        if self.container.take().is_none() {
+            return;
+        }
+        self.smtp_address = None;
+        self.http_api_url = None;
+        tracing::debug!(layer = "smtp_container", phase = "container_stopped");
+
+        if let Some(ref network) = self.network {
+            arena_container::network::remove_network(network).await;
+        }
+    }
+
+    fn smtp_address(&self) -> Option<&str> {
+        self.smtp_address.as_deref()
+    }
+
+    fn http_api_url(&self) -> Option<&str> {
+        self.http_api_url.as_deref()
+    }
+}

--- a/arena-smtp/src/smtp_dependency/healthcheck.rs
+++ b/arena-smtp/src/smtp_dependency/healthcheck.rs
@@ -1,0 +1,67 @@
+use arena::healthcheck::ReadinessCheck;
+use async_trait::async_trait;
+use futures_timer::Delay;
+use std::time::{Duration, Instant};
+use tokio::io::AsyncReadExt;
+use tokio::net::TcpStream;
+
+pub(super) struct DefaultSmtpReadinessCheck;
+
+const PROBE_TIMEOUT: Duration = Duration::from_secs(2);
+
+#[async_trait]
+impl ReadinessCheck for DefaultSmtpReadinessCheck {
+    async fn is_ready(
+        &self,
+        identifier: &str,
+        smtp_address: &str,
+        timeout_ms: u64,
+    ) -> Result<(), String> {
+        let timeout = Duration::from_millis(timeout_ms);
+        let poll_every = Duration::from_millis(100);
+        let start = Instant::now();
+
+        loop {
+            match probe_once(smtp_address).await {
+                Ok(()) => return Ok(()),
+                Err(err) => {
+                    if start.elapsed() >= timeout {
+                        return Err(format!(
+                            "[Smtp-{identifier}] readiness probe against {smtp_address} \
+                             did not succeed within {timeout:?}: {err}"
+                        ));
+                    }
+
+                    tracing::debug!(
+                        subsystem = "smtp",
+                        error = %err,
+                        "readiness probe failed (will retry)"
+                    );
+                    Delay::new(poll_every).await;
+                }
+            }
+        }
+    }
+}
+
+async fn probe_once(smtp_address: &str) -> Result<(), String> {
+    let mut stream = tokio::time::timeout(PROBE_TIMEOUT, TcpStream::connect(smtp_address))
+        .await
+        .map_err(|_| "connect timed out".to_string())?
+        .map_err(|err| err.to_string())?;
+
+    let mut buffer = [0u8; 3];
+    tokio::time::timeout(PROBE_TIMEOUT, stream.read_exact(&mut buffer))
+        .await
+        .map_err(|_| "banner read timed out".to_string())?
+        .map_err(|err| err.to_string())?;
+
+    if &buffer == b"220" {
+        Ok(())
+    } else {
+        Err(format!(
+            "unexpected smtp banner prefix: {}",
+            String::from_utf8_lossy(&buffer)
+        ))
+    }
+}

--- a/arena-smtp/tests/builder_test.rs
+++ b/arena-smtp/tests/builder_test.rs
@@ -1,0 +1,256 @@
+use arena::dependency::RunnableDependency;
+use arena::healthcheck::ReadinessCheck;
+use arena_smtp::{SmtpDependency, SmtpImpl};
+use async_trait::async_trait;
+use std::sync::{Arc, Mutex};
+
+#[derive(Debug, Clone, Default)]
+struct StartArgs {
+    smtp_port: u16,
+    ui_port: u16,
+    image_name: String,
+    image_tag: String,
+    container_name: String,
+}
+
+struct RecordingSmtpImpl {
+    recorded: Arc<Mutex<Option<StartArgs>>>,
+    smtp_address: Option<String>,
+    http_api_url: Option<String>,
+}
+
+#[async_trait]
+impl SmtpImpl for RecordingSmtpImpl {
+    async fn start(
+        &mut self,
+        smtp_port: u16,
+        ui_port: u16,
+        image_name: &str,
+        image_tag: &str,
+        container_name: &str,
+    ) {
+        *self.recorded.lock().unwrap() = Some(StartArgs {
+            smtp_port,
+            ui_port,
+            image_name: image_name.to_string(),
+            image_tag: image_tag.to_string(),
+            container_name: container_name.to_string(),
+        });
+        self.smtp_address = Some("127.0.0.1:1025".to_string());
+        self.http_api_url = Some("http://127.0.0.1:8025".to_string());
+    }
+
+    async fn stop(&mut self) {
+        self.smtp_address = None;
+        self.http_api_url = None;
+    }
+
+    fn smtp_address(&self) -> Option<&str> {
+        self.smtp_address.as_deref()
+    }
+
+    fn http_api_url(&self) -> Option<&str> {
+        self.http_api_url.as_deref()
+    }
+}
+
+struct OkReadinessCheck;
+
+#[async_trait]
+impl ReadinessCheck for OkReadinessCheck {
+    async fn is_ready(
+        &self,
+        _identifier: &str,
+        _smtp_address: &str,
+        _timeout_ms: u64,
+    ) -> Result<(), String> {
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ChildEvent {
+    Start,
+    Stop,
+}
+
+struct RecordingChildDependency {
+    events: Arc<Mutex<Vec<ChildEvent>>>,
+}
+
+#[async_trait]
+impl RunnableDependency for RecordingChildDependency {
+    fn identifier(&self) -> &str {
+        "child"
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
+    async fn start(&mut self) {
+        self.events.lock().unwrap().push(ChildEvent::Start);
+    }
+
+    async fn stop(&mut self) {
+        self.events.lock().unwrap().push(ChildEvent::Stop);
+    }
+
+    async fn soft_reset(&self) {}
+
+    async fn hard_reset(&mut self) {}
+
+    fn add_child(&mut self, _dep: Box<dyn RunnableDependency>) {}
+}
+
+#[tokio::test]
+async fn with_port_and_ui_port_propagate_to_impl_start() {
+    let recorded = Arc::new(Mutex::new(None::<StartArgs>));
+    let mut dep = SmtpDependency::builder("builder-ports")
+        .with_port(11111)
+        .with_ui_port(22222)
+        .with_impl(RecordingSmtpImpl {
+            recorded: recorded.clone(),
+            smtp_address: None,
+            http_api_url: None,
+        })
+        .with_readiness_check(OkReadinessCheck)
+        .build();
+
+    dep.start().await;
+    dep.stop().await;
+
+    let args = recorded
+        .lock()
+        .unwrap()
+        .clone()
+        .expect("start should have recorded args");
+    assert_eq!(args.smtp_port, 11111);
+    assert_eq!(args.ui_port, 22222);
+}
+
+#[tokio::test]
+async fn with_image_name_and_tag_propagate_to_impl_start() {
+    let recorded = Arc::new(Mutex::new(None::<StartArgs>));
+    let mut dep = SmtpDependency::builder("builder-image")
+        .with_image_name("example.com/custom-smtp")
+        .with_image_tag("9.9.9")
+        .with_impl(RecordingSmtpImpl {
+            recorded: recorded.clone(),
+            smtp_address: None,
+            http_api_url: None,
+        })
+        .with_readiness_check(OkReadinessCheck)
+        .build();
+
+    dep.start().await;
+    dep.stop().await;
+
+    let args = recorded
+        .lock()
+        .unwrap()
+        .clone()
+        .expect("start should have recorded args");
+    assert_eq!(args.image_name, "example.com/custom-smtp");
+    assert_eq!(args.image_tag, "9.9.9");
+}
+
+#[tokio::test]
+async fn with_image_alias_sets_same_tag_as_with_image_tag() {
+    let recorded = Arc::new(Mutex::new(None::<StartArgs>));
+    let mut dep = SmtpDependency::builder("builder-image-alias")
+        .with_image("1.30.5")
+        .with_impl(RecordingSmtpImpl {
+            recorded: recorded.clone(),
+            smtp_address: None,
+            http_api_url: None,
+        })
+        .with_readiness_check(OkReadinessCheck)
+        .build();
+
+    dep.start().await;
+    dep.stop().await;
+
+    let args = recorded
+        .lock()
+        .unwrap()
+        .clone()
+        .expect("start should have recorded args");
+    assert_eq!(args.image_tag, "1.30.5");
+}
+
+#[tokio::test]
+async fn with_container_tag_alias_sets_same_tag_as_with_image_tag() {
+    let recorded = Arc::new(Mutex::new(None::<StartArgs>));
+    let mut dep = SmtpDependency::builder("builder-container-tag-alias")
+        .with_container_tag("2.0.0")
+        .with_impl(RecordingSmtpImpl {
+            recorded: recorded.clone(),
+            smtp_address: None,
+            http_api_url: None,
+        })
+        .with_readiness_check(OkReadinessCheck)
+        .build();
+
+    dep.start().await;
+    dep.stop().await;
+
+    let args = recorded
+        .lock()
+        .unwrap()
+        .clone()
+        .expect("start should have recorded args");
+    assert_eq!(args.image_tag, "2.0.0");
+}
+
+#[tokio::test]
+async fn with_container_name_propagates_to_impl_start() {
+    let recorded = Arc::new(Mutex::new(None::<StartArgs>));
+    let mut dep = SmtpDependency::builder("builder-container-name")
+        .with_container_name("my-smtp-container")
+        .with_impl(RecordingSmtpImpl {
+            recorded: recorded.clone(),
+            smtp_address: None,
+            http_api_url: None,
+        })
+        .with_readiness_check(OkReadinessCheck)
+        .build();
+
+    dep.start().await;
+    dep.stop().await;
+
+    let args = recorded
+        .lock()
+        .unwrap()
+        .clone()
+        .expect("start should have recorded args");
+    assert_eq!(args.container_name, "my-smtp-container");
+}
+
+#[tokio::test]
+async fn with_child_dependencies_starts_and_stops_children() {
+    let events = Arc::new(Mutex::new(Vec::<ChildEvent>::new()));
+    let mut dep = SmtpDependency::builder("builder-children")
+        .with_child_dependencies(vec![Box::new(RecordingChildDependency {
+            events: events.clone(),
+        })])
+        .with_impl(RecordingSmtpImpl {
+            recorded: Arc::new(Mutex::new(None)),
+            smtp_address: None,
+            http_api_url: None,
+        })
+        .with_readiness_check(OkReadinessCheck)
+        .build();
+
+    dep.start().await;
+    dep.stop().await;
+
+    assert_eq!(
+        events.lock().unwrap().as_slice(),
+        &[ChildEvent::Start, ChildEvent::Stop]
+    );
+}

--- a/arena-smtp/tests/component_test.rs
+++ b/arena-smtp/tests/component_test.rs
@@ -1,0 +1,165 @@
+use arena::dependency::RunnableDependency;
+use arena_smtp::SmtpDependency;
+use futures::FutureExt;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+
+fn init_test_logging() {
+    let filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_test_writer()
+        .try_init();
+}
+
+struct TestContext {
+    smtp: SmtpDependency,
+    smtp_address: String,
+    http_api_url: String,
+}
+
+impl TestContext {
+    async fn new() -> Result<Self, String> {
+        let mut smtp = SmtpDependency::builder("").build();
+
+        let start_outcome = std::panic::AssertUnwindSafe(async { smtp.start().await })
+            .catch_unwind()
+            .await;
+        if let Err(panic_payload) = start_outcome {
+            smtp.stop().await;
+            std::panic::resume_unwind(panic_payload);
+        }
+
+        let smtp_address = smtp
+            .smtp_address()
+            .ok_or_else(|| "smtp address missing after start()".to_string())?
+            .to_string();
+        let http_api_url = smtp
+            .http_api_url()
+            .ok_or_else(|| "smtp http api url missing after start()".to_string())?
+            .to_string();
+
+        Ok(Self {
+            smtp,
+            smtp_address,
+            http_api_url,
+        })
+    }
+
+    async fn stop(mut self) {
+        self.smtp.stop().await;
+    }
+}
+
+async fn read_reply(stream: &mut TcpStream, expected_prefix: &str) -> Result<(), String> {
+    let mut buffer = [0u8; 512];
+    let read = tokio::time::timeout(Duration::from_secs(5), stream.read(&mut buffer))
+        .await
+        .map_err(|_| "smtp reply timed out".to_string())?
+        .map_err(|err| err.to_string())?;
+    let reply = String::from_utf8_lossy(&buffer[..read]);
+    if reply.starts_with(expected_prefix) {
+        Ok(())
+    } else {
+        Err(format!("expected reply prefix {expected_prefix}, got {reply}"))
+    }
+}
+
+async fn send_line(stream: &mut TcpStream, line: &str) -> Result<(), String> {
+    stream
+        .write_all(line.as_bytes())
+        .await
+        .map_err(|err| err.to_string())
+}
+
+async fn send_probe_message(smtp_address: &str, subject: &str) -> Result<(), String> {
+    let mut stream = TcpStream::connect(smtp_address)
+        .await
+        .map_err(|err| err.to_string())?;
+
+    read_reply(&mut stream, "220").await?;
+    send_line(&mut stream, "EHLO arena\r\n").await?;
+    read_reply(&mut stream, "250").await?;
+    send_line(&mut stream, "MAIL FROM:<sender@arena.test>\r\n").await?;
+    read_reply(&mut stream, "250").await?;
+    send_line(&mut stream, "RCPT TO:<recipient@arena.test>\r\n").await?;
+    read_reply(&mut stream, "250").await?;
+    send_line(&mut stream, "DATA\r\n").await?;
+    read_reply(&mut stream, "354").await?;
+    let body = format!(
+        "Subject: {subject}\r\nFrom: sender@arena.test\r\nTo: recipient@arena.test\r\n\r\nhello from arena\r\n.\r\n"
+    );
+    send_line(&mut stream, &body).await?;
+    read_reply(&mut stream, "250").await?;
+    send_line(&mut stream, "QUIT\r\n").await?;
+    read_reply(&mut stream, "221").await?;
+    Ok(())
+}
+
+async fn captured_message_count(http_api_url: &str, subject: &str) -> Result<usize, String> {
+    let url = format!("{http_api_url}/api/v1/messages");
+    let body = reqwest::get(&url)
+        .await
+        .map_err(|err| err.to_string())?
+        .text()
+        .await
+        .map_err(|err| err.to_string())?;
+    Ok(body.matches(subject).count())
+}
+
+#[tokio::test]
+async fn smtp_dependency_captures_sent_message_component_test() {
+    init_test_logging();
+
+    let ctx = match TestContext::new().await {
+        Ok(v) => v,
+        Err(e) => panic!("{e}"),
+    };
+
+    let subject = format!(
+        "arena-smtp-probe-{}",
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+
+    let outcome = std::panic::AssertUnwindSafe(async {
+        assert!(
+            !ctx.http_api_url.is_empty(),
+            "expected a non-empty smtp http api url"
+        );
+
+        send_probe_message(&ctx.smtp_address, &subject).await?;
+
+        let mut captured = 0;
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+        while tokio::time::Instant::now() < deadline {
+            captured = captured_message_count(&ctx.http_api_url, &subject).await?;
+            if captured >= 1 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+
+        if captured >= 1 {
+            Ok(())
+        } else {
+            Err(format!("sent message {subject} was not captured"))
+        }
+    })
+    .catch_unwind()
+    .await;
+
+    tokio::time::timeout(Duration::from_secs(10), ctx.stop())
+        .await
+        .unwrap_or_else(|_| panic!("smtp stop timed out"));
+
+    match outcome {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => panic!("{e}"),
+        Err(panic_payload) => std::panic::resume_unwind(panic_payload),
+    }
+}

--- a/arena-smtp/tests/drop_teardown_test.rs
+++ b/arena-smtp/tests/drop_teardown_test.rs
@@ -1,0 +1,145 @@
+use arena::dependency::RunnableDependency;
+use arena::healthcheck::ReadinessCheck;
+use arena_smtp::{SmtpDependency, SmtpImpl};
+use async_trait::async_trait;
+use futures::FutureExt;
+use std::sync::{Arc, Mutex};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Event {
+    SmtpStart,
+    SmtpStop,
+}
+
+struct FakeSmtpImpl {
+    smtp_address: Option<String>,
+    http_api_url: Option<String>,
+    events: Arc<Mutex<Vec<Event>>>,
+}
+
+#[async_trait]
+impl SmtpImpl for FakeSmtpImpl {
+    async fn start(
+        &mut self,
+        _smtp_port: u16,
+        _ui_port: u16,
+        _image_name: &str,
+        _image_tag: &str,
+        _container_name: &str,
+    ) {
+        self.smtp_address = Some("127.0.0.1:1025".to_string());
+        self.http_api_url = Some("http://127.0.0.1:8025".to_string());
+        self.events.lock().unwrap().push(Event::SmtpStart);
+    }
+
+    async fn stop(&mut self) {
+        self.smtp_address = None;
+        self.http_api_url = None;
+        self.events.lock().unwrap().push(Event::SmtpStop);
+    }
+
+    fn smtp_address(&self) -> Option<&str> {
+        self.smtp_address.as_deref()
+    }
+
+    fn http_api_url(&self) -> Option<&str> {
+        self.http_api_url.as_deref()
+    }
+}
+
+struct OkReadinessCheck;
+
+#[async_trait]
+impl ReadinessCheck for OkReadinessCheck {
+    async fn is_ready(
+        &self,
+        _identifier: &str,
+        _smtp_address: &str,
+        _timeout_ms: u64,
+    ) -> Result<(), String> {
+        Ok(())
+    }
+}
+
+struct PanickingSmtpReadinessCheck;
+
+#[async_trait]
+impl ReadinessCheck for PanickingSmtpReadinessCheck {
+    async fn is_ready(
+        &self,
+        _identifier: &str,
+        _smtp_address: &str,
+        _timeout_ms: u64,
+    ) -> Result<(), String> {
+        panic!("readiness probe failed");
+    }
+}
+
+fn smtp_stop_count(events: &[Event]) -> usize {
+    events
+        .iter()
+        .filter(|event| matches!(event, Event::SmtpStop))
+        .count()
+}
+
+fn build_smtp(events: Arc<Mutex<Vec<Event>>>) -> SmtpDependency {
+    SmtpDependency::builder("smtp-drop")
+        .with_impl(FakeSmtpImpl {
+            smtp_address: None,
+            http_api_url: None,
+            events,
+        })
+        .with_readiness_check(OkReadinessCheck)
+        .build()
+}
+
+#[test]
+fn drop_unstarted_dep_skips_impl_stop() {
+    let events = Arc::new(Mutex::new(Vec::<Event>::new()));
+    let dep = build_smtp(events.clone());
+    drop(dep);
+    assert_eq!(smtp_stop_count(&events.lock().unwrap()), 0);
+}
+
+#[tokio::test]
+async fn stop_then_drop_single_impl_stop() {
+    let events = Arc::new(Mutex::new(Vec::<Event>::new()));
+    let mut dep = build_smtp(events.clone());
+    dep.start().await;
+    dep.stop().await;
+    drop(dep);
+    assert_eq!(smtp_stop_count(&events.lock().unwrap()), 1);
+}
+
+#[tokio::test]
+async fn drop_running_dep_invokes_full_stop() {
+    let events = Arc::new(Mutex::new(Vec::<Event>::new()));
+    let mut dep = build_smtp(events.clone());
+    dep.start().await;
+    drop(dep);
+    assert_eq!(smtp_stop_count(&events.lock().unwrap()), 1);
+}
+
+#[tokio::test]
+async fn start_panic_then_drop_impl_stop() {
+    let events = Arc::new(Mutex::new(Vec::<Event>::new()));
+    let mut dep = SmtpDependency::builder("smtp-drop")
+        .with_impl(FakeSmtpImpl {
+            smtp_address: None,
+            http_api_url: None,
+            events: events.clone(),
+        })
+        .with_readiness_check(PanickingSmtpReadinessCheck)
+        .build();
+
+    let start_outcome = std::panic::AssertUnwindSafe(async {
+        dep.start().await;
+    })
+    .catch_unwind()
+    .await;
+    assert!(start_outcome.is_err());
+    assert_eq!(events.lock().unwrap().as_slice(), &[Event::SmtpStart]);
+
+    drop(dep);
+    assert_eq!(smtp_stop_count(&events.lock().unwrap()), 1);
+}

--- a/arena-smtp/tests/healthcheck_test.rs
+++ b/arena-smtp/tests/healthcheck_test.rs
@@ -1,0 +1,87 @@
+use arena::dependency::RunnableDependency;
+use arena_smtp::{SmtpDependency, SmtpImpl};
+use async_trait::async_trait;
+use std::time::Duration;
+use tokio::io::AsyncWriteExt;
+use tokio::net::TcpListener;
+
+struct FixedAddressSmtpImpl {
+    smtp_address: String,
+    http_api_url: String,
+}
+
+#[async_trait]
+impl SmtpImpl for FixedAddressSmtpImpl {
+    async fn start(
+        &mut self,
+        _smtp_port: u16,
+        _ui_port: u16,
+        _image_name: &str,
+        _image_tag: &str,
+        _container_name: &str,
+    ) {
+    }
+
+    async fn stop(&mut self) {}
+
+    fn smtp_address(&self) -> Option<&str> {
+        Some(&self.smtp_address)
+    }
+
+    fn http_api_url(&self) -> Option<&str> {
+        Some(&self.http_api_url)
+    }
+}
+
+#[tokio::test]
+async fn default_readiness_check_accepts_real_smtp_banner() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap().to_string();
+
+    tokio::spawn(async move {
+        if let Ok((mut socket, _)) = listener.accept().await {
+            let _ = socket.write_all(b"220 mailpit ready\r\n").await;
+        }
+    });
+
+    let mut dep = SmtpDependency::builder("smtp-real-banner")
+        .with_impl(FixedAddressSmtpImpl {
+            smtp_address: addr,
+            http_api_url: "http://127.0.0.1:8025".to_string(),
+        })
+        .build();
+
+    tokio::time::timeout(Duration::from_secs(5), dep.start())
+        .await
+        .expect("start should complete against a locally-ready banner");
+
+    dep.stop().await;
+}
+
+#[tokio::test]
+async fn default_readiness_check_retries_after_dropped_connection() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap().to_string();
+
+    tokio::spawn(async move {
+        if let Ok((socket, _)) = listener.accept().await {
+            drop(socket);
+        }
+        if let Ok((mut socket, _)) = listener.accept().await {
+            let _ = socket.write_all(b"220 mailpit ready\r\n").await;
+        }
+    });
+
+    let mut dep = SmtpDependency::builder("smtp-real-banner-retry")
+        .with_impl(FixedAddressSmtpImpl {
+            smtp_address: addr,
+            http_api_url: "http://127.0.0.1:8025".to_string(),
+        })
+        .build();
+
+    tokio::time::timeout(Duration::from_secs(5), dep.start())
+        .await
+        .expect("start should complete once the second connection succeeds");
+
+    dep.stop().await;
+}

--- a/arena-smtp/tests/unit_test.rs
+++ b/arena-smtp/tests/unit_test.rs
@@ -3,6 +3,7 @@ use arena::healthcheck::ReadinessCheck;
 use arena_smtp::{SmtpDependency, SmtpImpl};
 use async_trait::async_trait;
 use futures::FutureExt;
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, Mutex};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -106,8 +107,13 @@ async fn start_stop_happy_path_records_events() {
         })
         .build();
 
+    let http_api_url_while_running = Arc::new(Mutex::new(None::<String>));
+    let http_api_url_while_running_write = http_api_url_while_running.clone();
+
     let outcome = std::panic::AssertUnwindSafe(async {
         smtp.start().await;
+        *http_api_url_while_running_write.lock().unwrap() =
+            smtp.http_api_url().map(str::to_string);
         smtp.stop().await;
     })
     .catch_unwind()
@@ -128,6 +134,10 @@ async fn start_stop_happy_path_records_events() {
     assert_eq!(
         last_smtp_address.lock().unwrap().as_deref(),
         Some("127.0.0.1:1025")
+    );
+    assert_eq!(
+        http_api_url_while_running.lock().unwrap().as_deref(),
+        Some("http://127.0.0.1:8025")
     );
     let timeout_ms = last_timeout_ms
         .lock()
@@ -159,4 +169,207 @@ async fn start_readiness_err_panics_after_impl_start() {
 
     assert!(outcome.is_err());
     assert_eq!(events.lock().unwrap().as_slice(), &[Event::SmtpStart]);
+}
+
+struct AlwaysOkReadinessCheck;
+
+#[async_trait]
+impl ReadinessCheck for AlwaysOkReadinessCheck {
+    async fn is_ready(
+        &self,
+        _identifier: &str,
+        _smtp_address: &str,
+        _timeout_ms: u64,
+    ) -> Result<(), String> {
+        Ok(())
+    }
+}
+
+struct RetryingSmtpImpl {
+    smtp_address: String,
+    http_api_url: String,
+    address_polls: AtomicU32,
+    ready_after_polls: u32,
+}
+
+#[async_trait]
+impl SmtpImpl for RetryingSmtpImpl {
+    async fn start(
+        &mut self,
+        _smtp_port: u16,
+        _ui_port: u16,
+        _image_name: &str,
+        _image_tag: &str,
+        _container_name: &str,
+    ) {
+    }
+
+    async fn stop(&mut self) {}
+
+    fn smtp_address(&self) -> Option<&str> {
+        let polls = self.address_polls.fetch_add(1, Ordering::SeqCst) + 1;
+        if polls >= self.ready_after_polls {
+            Some(&self.smtp_address)
+        } else {
+            None
+        }
+    }
+
+    fn http_api_url(&self) -> Option<&str> {
+        Some(&self.http_api_url)
+    }
+}
+
+#[tokio::test]
+async fn wait_until_ready_retries_until_impl_reports_address() {
+    let mut dep = SmtpDependency::builder("smtp-retry")
+        .with_impl(RetryingSmtpImpl {
+            smtp_address: "127.0.0.1:1025".to_string(),
+            http_api_url: "http://127.0.0.1:8025".to_string(),
+            address_polls: AtomicU32::new(0),
+            ready_after_polls: 3,
+        })
+        .with_readiness_check(AlwaysOkReadinessCheck)
+        .build();
+
+    dep.start().await;
+    dep.stop().await;
+}
+
+#[tokio::test]
+async fn hard_reset_stops_and_restarts_impl() {
+    let events = Arc::new(Mutex::new(Vec::<Event>::new()));
+    let mut dep = SmtpDependency::builder("smtp-hard-reset")
+        .with_impl(FakeSmtpImpl {
+            smtp_address: None,
+            http_api_url: None,
+            events: events.clone(),
+        })
+        .with_readiness_check(AlwaysOkReadinessCheck)
+        .build();
+
+    dep.start().await;
+    dep.hard_reset().await;
+
+    assert_eq!(
+        events.lock().unwrap().as_slice(),
+        &[Event::SmtpStart, Event::SmtpStop, Event::SmtpStart]
+    );
+
+    dep.stop().await;
+}
+
+#[tokio::test]
+async fn soft_reset_before_start_is_noop() {
+    let events = Arc::new(Mutex::new(Vec::<Event>::new()));
+    let dep = SmtpDependency::builder("smtp-soft-reset-idle")
+        .with_impl(FakeSmtpImpl {
+            smtp_address: None,
+            http_api_url: None,
+            events: events.clone(),
+        })
+        .with_readiness_check(AlwaysOkReadinessCheck)
+        .build();
+
+    dep.soft_reset().await;
+
+    assert!(events.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn soft_reset_while_running_does_not_panic() {
+    let events = Arc::new(Mutex::new(Vec::<Event>::new()));
+    let mut dep = SmtpDependency::builder("smtp-soft-reset-running")
+        .with_impl(FakeSmtpImpl {
+            smtp_address: None,
+            http_api_url: None,
+            events: events.clone(),
+        })
+        .with_readiness_check(AlwaysOkReadinessCheck)
+        .build();
+
+    dep.start().await;
+    dep.soft_reset().await;
+    dep.stop().await;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ChildEvent {
+    Start,
+    Stop,
+}
+
+struct RecordingChild {
+    events: Arc<Mutex<Vec<ChildEvent>>>,
+}
+
+#[async_trait]
+impl RunnableDependency for RecordingChild {
+    fn identifier(&self) -> &str {
+        "child"
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
+    async fn start(&mut self) {
+        self.events.lock().unwrap().push(ChildEvent::Start);
+    }
+
+    async fn stop(&mut self) {
+        self.events.lock().unwrap().push(ChildEvent::Stop);
+    }
+
+    async fn soft_reset(&self) {}
+
+    async fn hard_reset(&mut self) {}
+
+    fn add_child(&mut self, _dep: Box<dyn RunnableDependency>) {}
+}
+
+#[tokio::test]
+async fn add_child_appends_and_lifecycle_includes_it() {
+    let child_events = Arc::new(Mutex::new(Vec::<ChildEvent>::new()));
+    let mut dep = SmtpDependency::builder("smtp-add-child")
+        .with_impl(FakeSmtpImpl {
+            smtp_address: None,
+            http_api_url: None,
+            events: Arc::new(Mutex::new(Vec::new())),
+        })
+        .with_readiness_check(AlwaysOkReadinessCheck)
+        .build();
+
+    dep.add_child(Box::new(RecordingChild {
+        events: child_events.clone(),
+    }));
+
+    dep.start().await;
+    dep.stop().await;
+
+    assert_eq!(
+        child_events.lock().unwrap().as_slice(),
+        &[ChildEvent::Start, ChildEvent::Stop]
+    );
+}
+
+#[tokio::test]
+async fn identifier_and_any_casts_expose_dependency() {
+    let mut dep = SmtpDependency::builder("smtp-any")
+        .with_impl(FakeSmtpImpl {
+            smtp_address: None,
+            http_api_url: None,
+            events: Arc::new(Mutex::new(Vec::new())),
+        })
+        .with_readiness_check(AlwaysOkReadinessCheck)
+        .build();
+
+    let expected_identifier = dep.identifier.clone();
+    assert_eq!(RunnableDependency::identifier(&dep), expected_identifier);
+    assert!(dep.as_any().downcast_ref::<SmtpDependency>().is_some());
+    assert!(dep.as_any_mut().downcast_mut::<SmtpDependency>().is_some());
 }

--- a/arena-smtp/tests/unit_test.rs
+++ b/arena-smtp/tests/unit_test.rs
@@ -1,0 +1,162 @@
+use arena::dependency::RunnableDependency;
+use arena::healthcheck::ReadinessCheck;
+use arena_smtp::{SmtpDependency, SmtpImpl};
+use async_trait::async_trait;
+use futures::FutureExt;
+use std::sync::{Arc, Mutex};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Event {
+    SmtpStart,
+    SmtpStop,
+    ReadinessCheck,
+}
+
+struct FakeSmtpImpl {
+    smtp_address: Option<String>,
+    http_api_url: Option<String>,
+    events: Arc<Mutex<Vec<Event>>>,
+}
+
+#[async_trait]
+impl SmtpImpl for FakeSmtpImpl {
+    async fn start(
+        &mut self,
+        _smtp_port: u16,
+        _ui_port: u16,
+        _image_name: &str,
+        _image_tag: &str,
+        _container_name: &str,
+    ) {
+        self.smtp_address = Some("127.0.0.1:1025".to_string());
+        self.http_api_url = Some("http://127.0.0.1:8025".to_string());
+        self.events.lock().unwrap().push(Event::SmtpStart);
+    }
+
+    async fn stop(&mut self) {
+        self.smtp_address = None;
+        self.http_api_url = None;
+        self.events.lock().unwrap().push(Event::SmtpStop);
+    }
+
+    fn smtp_address(&self) -> Option<&str> {
+        self.smtp_address.as_deref()
+    }
+
+    fn http_api_url(&self) -> Option<&str> {
+        self.http_api_url.as_deref()
+    }
+}
+
+struct FakeReadinessCheck {
+    events: Arc<Mutex<Vec<Event>>>,
+    last_identifier: Arc<Mutex<Option<String>>>,
+    last_smtp_address: Arc<Mutex<Option<String>>>,
+    last_timeout_ms: Arc<Mutex<Option<u64>>>,
+}
+
+#[async_trait]
+impl ReadinessCheck for FakeReadinessCheck {
+    async fn is_ready(
+        &self,
+        identifier: &str,
+        smtp_address: &str,
+        timeout_ms: u64,
+    ) -> Result<(), String> {
+        self.events.lock().unwrap().push(Event::ReadinessCheck);
+        *self.last_identifier.lock().unwrap() = Some(identifier.to_string());
+        *self.last_smtp_address.lock().unwrap() = Some(smtp_address.to_string());
+        *self.last_timeout_ms.lock().unwrap() = Some(timeout_ms);
+        Ok(())
+    }
+}
+
+struct FailingReadinessCheck;
+
+#[async_trait]
+impl ReadinessCheck for FailingReadinessCheck {
+    async fn is_ready(
+        &self,
+        _identifier: &str,
+        _smtp_address: &str,
+        _timeout_ms: u64,
+    ) -> Result<(), String> {
+        Err("readiness failed".to_string())
+    }
+}
+
+#[tokio::test]
+async fn start_stop_happy_path_records_events() {
+    let events = Arc::new(Mutex::new(Vec::<Event>::new()));
+    let last_identifier = Arc::new(Mutex::new(None::<String>));
+    let last_smtp_address = Arc::new(Mutex::new(None::<String>));
+    let last_timeout_ms = Arc::new(Mutex::new(None::<u64>));
+
+    let mut smtp = SmtpDependency::builder("smtp")
+        .with_impl(FakeSmtpImpl {
+            smtp_address: None,
+            http_api_url: None,
+            events: events.clone(),
+        })
+        .with_readiness_check(FakeReadinessCheck {
+            events: events.clone(),
+            last_identifier: last_identifier.clone(),
+            last_smtp_address: last_smtp_address.clone(),
+            last_timeout_ms: last_timeout_ms.clone(),
+        })
+        .build();
+
+    let outcome = std::panic::AssertUnwindSafe(async {
+        smtp.start().await;
+        smtp.stop().await;
+    })
+    .catch_unwind()
+    .await;
+
+    assert!(outcome.is_ok(), "expected start/stop not to panic");
+
+    let got = events.lock().unwrap().clone();
+    assert_eq!(
+        got,
+        vec![Event::SmtpStart, Event::ReadinessCheck, Event::SmtpStop]
+    );
+
+    assert_eq!(
+        last_identifier.lock().unwrap().as_deref(),
+        Some(smtp.identifier.as_str())
+    );
+    assert_eq!(
+        last_smtp_address.lock().unwrap().as_deref(),
+        Some("127.0.0.1:1025")
+    );
+    let timeout_ms = last_timeout_ms
+        .lock()
+        .unwrap()
+        .expect("readiness check should have been called with a timeout");
+    assert!(
+        timeout_ms <= 30_000,
+        "expected timeout_ms <= 30_000, got {timeout_ms}"
+    );
+}
+
+#[tokio::test]
+async fn start_readiness_err_panics_after_impl_start() {
+    let events = Arc::new(Mutex::new(Vec::<Event>::new()));
+    let mut dep = SmtpDependency::builder("smtp")
+        .with_impl(FakeSmtpImpl {
+            smtp_address: None,
+            http_api_url: None,
+            events: events.clone(),
+        })
+        .with_readiness_check(FailingReadinessCheck)
+        .build();
+
+    let outcome = std::panic::AssertUnwindSafe(async {
+        dep.start().await;
+    })
+    .catch_unwind()
+    .await;
+
+    assert!(outcome.is_err());
+    assert_eq!(events.lock().unwrap().as_slice(), &[Event::SmtpStart]);
+}

--- a/container_defaults.toml
+++ b/container_defaults.toml
@@ -32,3 +32,8 @@ tag = "4.14.0"
 id = "temporal"
 image = "temporalio/temporal"
 tag = "1.8.0"
+
+[[image]]
+id = "smtp"
+image = "axllent/mailpit"
+tag = "v1.30.5"


### PR DESCRIPTION
Adds arena-smtp, a new dependency crate wrapping a containerized SMTP mail-capture server (Mailpit, axllent/mailpit:v1.30.5) for testing outbound email. Sends mail to it, tests read captured messages via its HTTP API.

Rust-crate phase of the SMTP dependency (containerized mail-capture server). 

I'll add FFI/Python/Java bindings in a follow-up branch - similar to how temporal was added in https://github.com/daveepope/arena/pull/124 and https://github.com/daveepope/arena/pull/120

### Testing
- bazel build //arena-smtp:arena_smtp
- bazel test //arena-smtp:unit_test //arena-smtp:drop_teardown_test //arena-smtp:builder_test 
- bazel test //arena-smtp:component_test 