### PR TITLE
Add bazel as a new builder

### DIFF
--- a/arena-executable-component/BUILD
+++ b/arena-executable-component/BUILD
@@ -1,4 +1,4 @@
-load("@rules_rust//rust:defs.bzl", "rust_library")
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 load("@crates//:defs.bzl", "all_crate_deps")
 
 rust_library(
@@ -11,4 +11,11 @@ rust_library(
     ],
     proc_macro_deps = all_crate_deps(proc_macro = True),
     visibility = ["//visibility:public"],
+)
+
+rust_test(
+    name = "executable_component_lib_unit_test",
+    crate = ":arena_executable_component",
+    size = "small",
+    edition = "2021",
 )

--- a/arena-executable-component/src/builder.rs
+++ b/arena-executable-component/src/builder.rs
@@ -201,11 +201,7 @@ impl ExecutableComponentBuilder {
                 .current_dir(source_dir)
                 .output()
                 .expect("failed to run cmake"),
-            BuildTool::Bazel { target, args } => std::process::Command::new("bazel")
-                .arg("build")
-                .args(args)
-                .arg(target)
-                .current_dir(source_dir)
+            BuildTool::Bazel { target, args } => Self::build_bazel_command(source_dir, target, args)
                 .output()
                 .expect("failed to run bazel build"),
             BuildTool::Custom { command, args } => std::process::Command::new(command)
@@ -214,5 +210,37 @@ impl ExecutableComponentBuilder {
                 .output()
                 .expect(&format!("failed to run custom build command: {}", command)),
         }
+    }
+
+    fn build_bazel_command(
+        source_dir: &PathBuf,
+        target: &str,
+        args: &[String],
+    ) -> std::process::Command {
+        let mut cmd = std::process::Command::new("bazel");
+        cmd.arg("build").args(args).arg(target).current_dir(source_dir);
+        cmd
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_bazel_command_target_and_args_returns_bazel_build_invocation() {
+        let source_dir = PathBuf::from("/tmp/example-source");
+        let args = vec!["--config=ci".to_string()];
+
+        let cmd = ExecutableComponentBuilder::build_bazel_command(
+            &source_dir,
+            "//foo:bar",
+            &args,
+        );
+
+        assert_eq!(cmd.get_program(), "bazel");
+        let cmd_args: Vec<&str> = cmd.get_args().map(|a| a.to_str().unwrap()).collect();
+        assert_eq!(cmd_args, vec!["build", "--config=ci", "//foo:bar"]);
+        assert_eq!(cmd.get_current_dir(), Some(source_dir.as_path()));
     }
 }

--- a/arena-executable-component/src/builder.rs
+++ b/arena-executable-component/src/builder.rs
@@ -10,6 +10,7 @@ pub enum BuildTool {
     Dotnet,
     Make,
     CMake,
+    Bazel { target: String, args: Vec<String> },
     Custom { command: String, args: Vec<String> },
 }
 
@@ -200,6 +201,13 @@ impl ExecutableComponentBuilder {
                 .current_dir(source_dir)
                 .output()
                 .expect("failed to run cmake"),
+            BuildTool::Bazel { target, args } => std::process::Command::new("bazel")
+                .arg("build")
+                .args(args)
+                .arg(target)
+                .current_dir(source_dir)
+                .output()
+                .expect("failed to run bazel build"),
             BuildTool::Custom { command, args } => std::process::Command::new(command)
                 .args(args)
                 .current_dir(source_dir)


### PR DESCRIPTION
Adding bazel support alongside existing builders e.g. make, gradle, etc. This is just adding it to `arena-executable-component`, a follow up will add it to ffi, junit, pytest.